### PR TITLE
fix: use separate encoding formats for comms with user-agent vs authenticators

### DIFF
--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -16,10 +16,22 @@ module WebAuthn
 
   def self.credential_creation_options
     {
-      challenge: Base64.urlsafe_encode64(SecureRandom.random_bytes(16)),
+      challenge: ua_encode(SecureRandom.random_bytes(16)),
       pubKeyCredParams: [ES256_ALGORITHM],
       rp: { name: RP_NAME },
-      user: { name: USER_NAME, displayName: USER_NAME, id: Base64.urlsafe_encode64(USER_ID) }
+      user: { name: USER_NAME, displayName: USER_NAME, id: ua_encode(USER_ID) }
     }
+  end
+
+  def self.ua_encode(bin)
+    Base64.strict_encode64(bin)
+  end
+
+  def self.ua_decode(str)
+    Base64.strict_decode64(str)
+  end
+
+  def self.authenticator_decode(str)
+    Base64.urlsafe_decode64(str)
   end
 end

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -38,7 +38,7 @@ module WebAuthn
     end
 
     def valid_challenge?(original_challenge)
-      Base64.urlsafe_decode64(client_data.challenge) == Base64.urlsafe_decode64(original_challenge)
+      WebAuthn.authenticator_decode(client_data.challenge) == WebAuthn.ua_decode(original_challenge)
     end
 
     def valid_origin?(original_origin)
@@ -73,7 +73,7 @@ module WebAuthn
     end
 
     def attestation
-      @attestation ||= CBOR.decode(Base64.urlsafe_decode64(attestation_object))
+      @attestation ||= CBOR.decode(WebAuthn.ua_decode(attestation_object))
     end
   end
 end

--- a/lib/webauthn/client_data.rb
+++ b/lib/webauthn/client_data.rb
@@ -29,7 +29,7 @@ module WebAuthn
     attr_reader :client_data_json
 
     def decoded_client_data_json
-      @decoded_client_data_json ||= Base64.urlsafe_decode64(client_data_json)
+      @decoded_client_data_json ||= WebAuthn.ua_decode(client_data_json)
     end
 
     def data

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,9 +51,13 @@ def seeds
 end
 
 def hash_to_encoded_json(hash)
-  Base64.urlsafe_encode64(hash.to_json)
+  WebAuthn.ua_encode(hash.to_json)
 end
 
 def hash_to_encoded_cbor(hash)
-  Base64.urlsafe_encode64(CBOR.encode(hash))
+  WebAuthn.ua_encode(CBOR.encode(hash))
+end
+
+def authenticator_encode(bin)
+  Base64.urlsafe_encode64(bin, padding: false)
 end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -44,11 +44,10 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
   describe "origin validation" do
     let(:original_origin) { "http://localhost" }
-    let(:challenge) {
-      Base64.urlsafe_encode64(SecureRandom.random_bytes(16))
-    }
+    let(:challenge) { SecureRandom.random_bytes(16) }
+    let(:original_challenge) { WebAuthn.ua_encode(challenge) }
     let(:client_data_json) {
-      hash_to_encoded_json(challenge: challenge,
+      hash_to_encoded_json(challenge: authenticator_encode(challenge),
                            clientExtensions: {},
                            hashAlgorithm: "SHA-256",
                            origin: origin,
@@ -76,7 +75,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
           client_data_json: client_data_json
         )
 
-        expect(response.valid?(challenge, original_origin)).to be_truthy
+        expect(response.valid?(original_challenge, original_origin)).to be_truthy
       end
     end
 
@@ -89,18 +88,17 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
           client_data_json: client_data_json
         )
 
-        expect(response.valid?(challenge, original_origin)).to be_falsy
+        expect(response.valid?(original_challenge, original_origin)).to be_falsy
       end
     end
   end
 
   describe "rp_id validation" do
     let(:original_origin) { "http://localhost:3000" }
-    let(:challenge) {
-      Base64.urlsafe_encode64(SecureRandom.random_bytes(16))
-    }
+    let(:challenge) { SecureRandom.random_bytes(16) }
+    let(:original_challenge) { WebAuthn.ua_encode(challenge) }
     let(:client_data_json) {
-      hash_to_encoded_json(challenge: challenge,
+      hash_to_encoded_json(challenge: authenticator_encode(challenge),
                            clientExtensions: {},
                            hashAlgorithm: "SHA-256",
                            origin: original_origin,
@@ -126,7 +124,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
           client_data_json: client_data_json
         )
 
-        expect(response.valid?(challenge, original_origin)).to be_truthy
+        expect(response.valid?(original_challenge, original_origin)).to be_truthy
       end
     end
 
@@ -139,7 +137,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
           client_data_json: client_data_json
         )
 
-        expect(response.valid?(challenge, original_origin)).to be_falsy
+        expect(response.valid?(original_challenge, original_origin)).to be_falsy
       end
     end
   end

--- a/spec/webauthn_spec.rb
+++ b/spec/webauthn_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WebAuthn do
     end
 
     it "has a 16 byte length challenge" do
-      original_challenge = Base64.urlsafe_decode64(@credential_creation_options[:challenge])
+      original_challenge = Base64.strict_decode64(@credential_creation_options[:challenge])
       expect(original_challenge.length).to eq(16)
     end
 


### PR DESCRIPTION

WebAuthn Recommendation reference:
https://w3c.github.io/webauthn/#base64url-encoding