### PR TITLE
docs: update README with latest browser release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Easily implement WebAuthn in your ruby web server
 ### User Agent compatibility
 
 So far, the only browser that have web authentication support are:
-  - Mozilla Firefox Quantum 60+ (Enabled by default).
-  - Google Chrome 65+ (Disabled by default, go to chrome://flags to enable Web Authentication API feature). Note: it is enabled by default in 67+ as stated [here](https://www.chromestatus.com/feature/5669923372138496).
+  - Mozilla Firefox Quantum 60+ ([Enabled by default](https://www.mozilla.org/en-US/firefox/60.0/releasenotes/))
+  - Google Chrome 67+ ([Enabled by default](https://www.chromestatus.com/feature/5669923372138496))
+  - Google Chrome 65 & 66 (Disabled by default, go to chrome://flags to enable Web Authentication API feature)
 
 ### Authenticator devices
 


### PR DESCRIPTION
Given the fact that Chrome 67 is now released, I updated the README.
I think this reads a little bit better :)