### PR TITLE
feat: Make methods public to expose data available

### DIFF
--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -18,6 +18,10 @@ module WebAuthn
         valid_signature?(credential_public_key(allowed_credentials))
     end
 
+    def authenticator_data
+      @authenticator_data ||= WebAuthn::AuthenticatorData.new(authenticator_data_bytes)
+    end
+
     private
 
     attr_reader :credential_id, :authenticator_data_bytes, :signature
@@ -40,10 +44,6 @@ module WebAuthn
       allowed_credential_ids = allowed_credentials.map { |credential| credential[:id] }
 
       allowed_credential_ids.include?(credential_id)
-    end
-
-    def authenticator_data
-      @authenticator_data ||= WebAuthn::AuthenticatorData.new(authenticator_data_bytes)
     end
 
     def credential_public_key(allowed_credentials)

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -26,10 +26,6 @@ module WebAuthn
       authenticator_data.credential
     end
 
-    private
-
-    attr_reader :attestation_object
-
     def attestation_statement
       @attestation_statement ||=
         WebAuthn::AttestationStatement.from(attestation["fmt"], attestation["attStmt"])
@@ -46,6 +42,10 @@ module WebAuthn
     def attestation
       @attestation ||= CBOR.decode(attestation_object)
     end
+
+    private
+
+    attr_reader :attestation_object
 
     def type
       WebAuthn::TYPES[:create]

--- a/lib/webauthn/authenticator_data.rb
+++ b/lib/webauthn/authenticator_data.rb
@@ -17,6 +17,8 @@ module WebAuthn
       @data = data
     end
 
+    attr_reader :data
+
     def valid?
       if attested_credential_data_included?
         data.length > base_length && attested_credential_data.valid?
@@ -27,6 +29,10 @@ module WebAuthn
 
     def user_present?
       flags[USER_PRESENT_FLAG_POSITION] == "1"
+    end
+
+    def attested_credential_data_included?
+      flags[ATTESTED_CREDENTIAL_DATA_INCLUDED_FLAG_POSITION] == "1"
     end
 
     def rp_id_hash
@@ -40,14 +46,16 @@ module WebAuthn
       attested_credential_data.credential
     end
 
-    private
-
-    attr_reader :data
-
     def attested_credential_data
       @attested_credential_data ||=
         AttestedCredentialData.new(data_at(attested_credential_data_position))
     end
+
+    def flags
+      @flags ||= data_at(flags_position, FLAGS_LENGTH).unpack1("b*")
+    end
+
+    private
 
     def attested_credential_data_position
       base_length
@@ -57,16 +65,8 @@ module WebAuthn
       RP_ID_HASH_LENGTH + FLAGS_LENGTH + SIGN_COUNT_LENGTH
     end
 
-    def flags
-      @flags ||= data_at(flags_position, FLAGS_LENGTH).unpack1("b*")
-    end
-
     def flags_position
       RP_ID_HASH_LENGTH
-    end
-
-    def attested_credential_data_included?
-      flags[ATTESTED_CREDENTIAL_DATA_INCLUDED_FLAG_POSITION] == "1"
     end
 
     def data_at(position, length = nil)

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -15,16 +15,16 @@ module WebAuthn
         authenticator_data.user_present?
     end
 
+    def client_data
+      @client_data ||= WebAuthn::ClientData.new(client_data_json)
+    end
+
     private
 
     attr_reader :client_data_json
 
     def valid_type?
       client_data.type == type
-    end
-
-    def client_data
-      @client_data ||= WebAuthn::ClientData.new(client_data_json)
     end
 
     def valid_challenge?(original_challenge)


### PR DESCRIPTION
Hi! Thank you for working on WebAuthn RP helper library for Ruby. I'm maintaining https://github.com/sorah/clarion, which was implemented with legacy U2F API (u2f-api.js), and I have just replaced the legacy implementation of my app with this gem!

Current implementation hides many data available from authenticators behind the private methods. It is useful to expose them to users of this gem, i.e. logging, auditing, and debugging.

I believe this gem should provide a low-level API for RP implementations. Current implementation doesn't expose the most data available from authenticator, and have to implement reference at the entry points (`AuthenticatorAttestationResponse` and `AuthenticatorAssersionResponse`.)

AFAIK WebAuthn is designed to be extensible, so it's useless to force RP developers to implement vendor or enterprise-specific extension into this gem.

(I'm gonna send more PRs and issues I noticed...)