### PR TITLE
feat: Accept rp_id explicitly on *Response#valid?

### DIFF
--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -12,8 +12,8 @@ module WebAuthn
       @signature = signature
     end
 
-    def valid?(original_challenge, original_origin, allowed_credentials:)
-      super(original_challenge, original_origin) &&
+    def valid?(original_challenge, original_origin, allowed_credentials:, rp_id: nil)
+      super(original_challenge, original_origin, rp_id: rp_id) &&
         valid_credential?(allowed_credentials) &&
         valid_signature?(credential_public_key(allowed_credentials))
     end

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -17,7 +17,7 @@ module WebAuthn
       @attestation_object = attestation_object
     end
 
-    def valid?(original_challenge, original_origin)
+    def valid?(original_challenge, original_origin, rp_id: nil)
       super &&
         attestation_statement.valid?(authenticator_data, client_data.hash)
     end

--- a/spec/webauthn/authenticator_assertion_response_spec.rb
+++ b/spec/webauthn/authenticator_assertion_response_spec.rb
@@ -168,5 +168,18 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
         )
       ).to be_falsy
     end
+
+    context "when rp_id is explicitly given" do
+      it "is valid if correct rp_id is given" do
+        expect(
+          assertion_response.valid?(
+            original_challenge,
+            original_origin,
+            allowed_credentials: allowed_credentials,
+            rp_id: "different-rp_id",
+          )
+        ).to be_truthy
+      end
+    end
   end
 end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -115,5 +115,18 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
         expect(response.valid?(original_challenge, original_origin)).to be_falsy
       end
     end
+
+    context "matches the one explicitly given" do
+      let(:rp_id) { "custom" }
+
+      it "is invalid" do
+        response = WebAuthn::AuthenticatorAttestationResponse.new(
+          attestation_object: authenticator.attestation_object,
+          client_data_json: authenticator.client_data_json
+        )
+
+        expect(response.valid?(original_challenge, original_origin, rp_id: "custom")).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/cedarcode/webauthn-ruby/issues/72

RP ID may be different from request origin; i.e. client may override, or the appid extension may give legacy app id as a RP ID.

In most cases, rp_id can be expected to be a host part of request origin URI. So this patch allows `valid?` methods to take optional `rp_id`, then the methods handle the explicitly given one as a RP ID, instead of a host of origin URI, when it's given.

``` ruby
attestation.valid?(challenge, "https://a.example.com", rp_id: "example.com")
assertion.valid?(challenge, "https://a.example.com", rp_id: "https://a.example.com") # in case of +appid+ extension
```