### PR TITLE
feat: Ruby 2.3 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3
   DisabledByDefault: true
 
 Bundler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.6.0-preview2
   - 2.5.3
   - 2.4.5
-
+  - 2.3.8
 matrix:
   fast_finish: true
   allow_failures:

--- a/lib/webauthn/authenticator_data.rb
+++ b/lib/webauthn/authenticator_data.rb
@@ -58,7 +58,7 @@ module WebAuthn
     end
 
     def sign_count
-      @sign_count ||= data_at(SIGN_COUNT_POSITION, SIGN_COUNT_LENGTH).unpack1('L>')
+      @sign_count ||= data_at(SIGN_COUNT_POSITION, SIGN_COUNT_LENGTH).unpack('L>')[0]
     end
 
     def attested_credential_data
@@ -67,7 +67,7 @@ module WebAuthn
     end
 
     def flags
-      @flags ||= data_at(flags_position, FLAGS_LENGTH).unpack1("b*")
+      @flags ||= data_at(flags_position, FLAGS_LENGTH).unpack("b*")[0]
     end
 
     private

--- a/lib/webauthn/authenticator_data/attested_credential_data.rb
+++ b/lib/webauthn/authenticator_data/attested_credential_data.rb
@@ -59,7 +59,7 @@ module WebAuthn
       end
 
       def id_length
-        @id_length ||= data_at(id_length_position, ID_LENGTH_LENGTH).unpack1(UINT16_BIG_ENDIAN_FORMAT)
+        @id_length ||= data_at(id_length_position, ID_LENGTH_LENGTH).unpack(UINT16_BIG_ENDIAN_FORMAT)[0]
       end
 
       def id_length_position

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -27,11 +27,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.3"
 
   spec.add_dependency "cbor", "~> 0.5.9.2"
   spec.add_dependency "cose", "~> 0.1.0"
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
+  spec.add_dependency "openssl", ">= 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "byebug", "~> 10.0"


### PR DESCRIPTION
Refinements are only effective in the file and at the point where `using` is called. So this doesn't leak over into other code.

Unfortunately I couldn't get a refinement for the following test failures working:
```
Failure/Error:
  @signature ||= credential_key.sign(
    "SHA256",
    authenticator_data + OpenSSL::Digest::SHA256.digest(client_data_json)
  )

NoMethodError:
  undefined method `private?' for #<OpenSSL::PKey::EC:0x007fbf0412af78 @group=nil>
       Did you mean?  private_key?
# ./spec/support/fake_authenticator.rb:106:in `sign'
# ./spec/support/fake_authenticator.rb:106:in `signature'
# ./spec/webauthn/authenticator_assertion_response_spec.rb:28:in `block (2 levels) in <top (required)>'
# ./spec/webauthn/authenticator_assertion_response_spec.rb:34:in `block (2 levels) in <top (required)>'
```
I suspect it's because `OpenSSL::PKey::EC` is completely defined in a C extension. Fortunately, OpenSSL has been gemified and the 2.0 version (which comes standard with Ruby 2.4) also works on 2.3.

Another possible solution would be a workaround like https://github.com/unixcharles/acme-client/blob/cef0f65f1043b76a927239158375976ebf8fea34/lib/acme/client/certificate_request/ec_key_patch.rb.