### PR TITLE
feat: expose attestation type and trust path after validation

### DIFF
--- a/lib/webauthn/attestation_statement.rb
+++ b/lib/webauthn/attestation_statement.rb
@@ -9,6 +9,13 @@ module WebAuthn
     ATTESTATION_FORMAT_PACKED = 'packed'
     ATTESTATION_FORMAT_ANDROID_SAFETYNET = "android-safetynet"
 
+    ATTESTATION_TYPE_NONE = "None"
+    ATTESTATION_TYPE_BASIC = "Basic"
+    ATTESTATION_TYPE_SELF = "Self"
+    ATTESTATION_TYPE_ATTCA = "AttCA"
+    ATTESTATION_TYPE_ECDAA = "ECDAA"
+    ATTESTATION_TYPE_BASIC_OR_ATTCA = "Basic_or_AttCA"
+
     def self.from(format, statement)
       case format
       when ATTESTATION_FORMAT_NONE

--- a/lib/webauthn/attestation_statement/android_safetynet.rb
+++ b/lib/webauthn/attestation_statement/android_safetynet.rb
@@ -18,7 +18,8 @@ module WebAuthn
           valid_attestation_domain? &&
           valid_version? &&
           valid_nonce?(authenticator_data, client_data_hash) &&
-          cts_profile_match?
+          cts_profile_match? &&
+          [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC, attestation_certificate]
       end
 
       private

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "webauthn/attestation_statement/types"
-
 module WebAuthn
   module AttestationStatement
     class Base

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "webauthn/attestation_statement/types"
+
 module WebAuthn
   module AttestationStatement
     class Base

--- a/lib/webauthn/attestation_statement/fido_u2f.rb
+++ b/lib/webauthn/attestation_statement/fido_u2f.rb
@@ -11,7 +11,8 @@ module WebAuthn
       def valid?(authenticator_data, client_data_hash)
         valid_format? &&
           valid_certificate_public_key? &&
-          valid_signature?(authenticator_data, client_data_hash)
+          valid_signature?(authenticator_data, client_data_hash) &&
+          [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC_OR_ATTCA, [attestation_certificate]]
       end
 
       private

--- a/lib/webauthn/attestation_statement/none.rb
+++ b/lib/webauthn/attestation_statement/none.rb
@@ -6,7 +6,7 @@ module WebAuthn
   module AttestationStatement
     class None < Base
       def valid?(*_args)
-        true
+        [WebAuthn::AttestationStatement::ATTESTATION_TYPE_NONE, nil]
       end
     end
   end

--- a/lib/webauthn/attestation_statement/packed.rb
+++ b/lib/webauthn/attestation_statement/packed.rb
@@ -15,7 +15,8 @@ module WebAuthn
         valid_format? &&
           valid_certificate_chain?(authenticator_data.credential) &&
           meet_certificate_requirement? &&
-          valid_signature?(authenticator_data, client_data_hash)
+          valid_signature?(authenticator_data, client_data_hash) &&
+          attestation_type_and_trust_path
       end
 
       private
@@ -85,6 +86,14 @@ module WebAuthn
 
       def verification_data(authenticator_data, client_data_hash)
         authenticator_data.data + client_data_hash
+      end
+
+      def attestation_type_and_trust_path
+        if raw_attestation_certificates&.any?
+          [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC_OR_ATTCA, attestation_certificate_chain]
+        else
+          [WebAuthn::AttestationStatement::ATTESTATION_TYPE_SELF, nil]
+        end
       end
     end
   end

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -11,6 +11,8 @@ require "webauthn/client_data"
 
 module WebAuthn
   class AuthenticatorAttestationResponse < AuthenticatorResponse
+    attr_reader :attestation_type, :attestation_trust_path
+
     def initialize(attestation_object:, **options)
       super(options)
 
@@ -18,8 +20,14 @@ module WebAuthn
     end
 
     def valid?(original_challenge, original_origin, rp_id: nil)
-      super &&
-        attestation_statement.valid?(authenticator_data, client_data.hash)
+      valid_response = super
+      return false unless valid_response
+
+      valid_attestation = attestation_statement.valid?(authenticator_data, client_data.hash)
+      return false unless valid_attestation
+
+      @attestation_type, @attestation_trust_path = valid_attestation
+      true
     end
 
     def credential

--- a/spec/webauthn/attestation_statement/packed_spec.rb
+++ b/spec/webauthn/attestation_statement/packed_spec.rb
@@ -24,11 +24,8 @@ RSpec.describe WebAuthn::AttestationStatement::Packed do
   end
 
   it "is valid if everything's in place" do
-    expect(
-      subject.valid?(
-        authenticator_data,
-        client_data_hash
-      )
-    )
+    attestation_type, attestation_trust_path = subject.valid?(authenticator_data, client_data_hash)
+    expect(attestation_type).to eq("Basic_or_AttCA")
+    expect(attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
   end
 end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     )
 
     expect(response.valid?(original_challenge, original_origin)).to eq(true)
+    expect(response.attestation_type).to eq("Basic_or_AttCA")
+    expect(response.attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
     expect(response.credential.id.length).to be >= 16
   end
 
@@ -55,6 +57,8 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     )
 
     expect(response.valid?(original_challenge, original_origin)).to eq(true)
+    expect(response.attestation_type).to eq("Self")
+    expect(response.attestation_trust_path).to eq(nil)
     expect(response.credential.id.length).to be >= 16
   end
 
@@ -71,6 +75,8 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     )
 
     expect(response.valid?(original_challenge, original_origin)).to eq(true)
+    expect(response.attestation_type).to eq("Basic")
+    expect(response.attestation_trust_path).to be_kind_of(OpenSSL::X509::Certificate)
     expect(response.credential.id.length).to be >= 16
   end
 


### PR DESCRIPTION
The WebAuthn spec [notes](https://www.w3.org/TR/2018/CR-webauthn-20180807/#sctn-attestation-types) the following:

> Attestation statements conveying attestations of type AttCA use the same data structure as attestation statements conveying attestations of type Basic, so the two attestation types are, in general, distinguishable only with externally provided knowledge regarding the contents of the attestation certificates conveyed in the attestation

[Retrieving](https://fidoalliance.org/mds/) and managing the this external data ([TOC](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-metadata-service-v2.0-id-20180227.html) and [statements](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-metadata-statement-v2.0-id-20180227.html)) from the FIDO Metadata Service is up to the implementing application (for now? https://github.com/cedarcode/webauthn-ruby/issues/66) if so desired.

Closes https://github.com/cedarcode/webauthn-ruby/issues/80