### PR TITLE
Use constant time compare function for challenge comparison 

### DIFF
--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -3,6 +3,7 @@
 require "cose/ecdsa"
 require "webauthn/authenticator_attestation_response"
 require "webauthn/authenticator_assertion_response"
+require "webauthn/security_utils"
 require "webauthn/version"
 
 require "base64"

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -28,7 +28,7 @@ module WebAuthn
     end
 
     def valid_challenge?(original_challenge)
-      Base64.urlsafe_decode64(client_data.challenge) == original_challenge
+      WebAuthn::SecurityUtils.secure_compare(Base64.urlsafe_decode64(client_data.challenge), original_challenge)
     end
 
     def valid_origin?(original_origin)

--- a/lib/webauthn/security_utils.rb
+++ b/lib/webauthn/security_utils.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module WebAuthn
+  module SecurityUtils
+    # Constant time string comparison, for variable length strings.
+    # This code was adapted from Rails ActiveSupport::SecurityUtils
+    #
+    # The values are first processed by SHA256, so that we don't leak length info
+    # via timing attacks.
+    def secure_compare(first_string, second_string)
+      first_string_sha256 = ::Digest::SHA256.hexdigest(first_string)
+      second_string_sha256 = ::Digest::SHA256.hexdigest(second_string)
+      fixed_length_secure_compare(first_string_sha256, second_string_sha256) && first_string == second_string
+    end
+    module_function :secure_compare
+
+    private
+
+    # Constant time string comparison, for fixed length strings.
+    # This code was adapted from Rails ActiveSupport::SecurityUtils
+    #
+    # The values compared should be of fixed length, such as strings
+    # that have already been processed by HMAC. Raises in case of length mismatch.
+    def fixed_length_secure_compare(first_string, second_string)
+      raise ArgumentError, "string length mismatch." unless first_string.bytesize == second_string.bytesize
+
+      l = first_string.unpack "C#{first_string.bytesize}"
+
+      res = 0
+      second_string.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
+    module_function :fixed_length_secure_compare
+  end
+end

--- a/spec/webauthn/security_utils_spec.rb
+++ b/spec/webauthn/security_utils_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe WebAuthn::SecurityUtils do
+  describe "#secure_compare" do
+    it "returns true if the two strings are equal" do
+      expect(WebAuthn::SecurityUtils.secure_compare("a", "a")).to be true
+    end
+
+    it "returns false if the two strings are not equal" do
+      expect(WebAuthn::SecurityUtils.secure_compare("a", "b")).to be false
+    end
+
+    it "returns false if the two strings are not equal length" do
+      expect(WebAuthn::SecurityUtils.secure_compare("a", "aa")).to be false
+    end
+  end
+
+  describe "#fixed_length_secure_compare" do
+    it "returns true if the two strings are equal and of equal length" do
+      expect(WebAuthn::SecurityUtils.fixed_length_secure_compare("a", "a")).to be true
+    end
+
+    it "raises an ArugmentError if the two strings are not equal length" do
+      expect do
+        WebAuthn::SecurityUtils.fixed_length_secure_compare("a", "ab")
+      end.to raise_error(ArgumentError, "string length mismatch.")
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/cedarcode/webauthn-ruby/commit/f1dc1c45846b1585aae75c131ebe4d347f81ceba adds a constant time comparision function called `secure_compare` to a `WebAuth::SecurityUtils` module. The code was adapted from https://github.com/rails/rails/blob/master/activesupport/lib/active_support/security_utils.rb.

https://github.com/cedarcode/webauthn-ruby/commit/f83f38b52e4ba29a3afaeb122fb01f474f59c0a5 replaces the `==` operator when comparing the challenge. `==` in Ruby is vulnerable to [timing attacks](https://www.slideshare.net/NickMalcolm/timing-attacks-and-ruby-on-rails). (Practical exploitation over the internet is very difficult, but better safe than sorry).

I would have ideally made `fixed_length_secure_compare` a private method but I guess you can't do that with modules?