### PR TITLE
build: loosen bundler version requirement to allow 1.17 and 2.0

### DIFF
--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
   spec.add_dependency "openssl", "~> 2.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "byebug", "~> 10.0"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.8"


### PR DESCRIPTION
For reasons we can't upgrade bundler yet at the moment where I work, and I don't believe anything is this gem actually requires 2.0. Loosening this requirement makes it just a bit easier to contribute in case other have a similar situation.