### PR TITLE
Fix Android SafetyNet tests that were failing due to time issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: ruby
 cache: bundler
 rvm:
@@ -14,4 +13,11 @@ matrix:
     - rvm: ruby-head
 
 before_install:
+  - wget http://archive.ubuntu.com/ubuntu/pool/universe/f/faketime/libfaketime_0.9.7-3_amd64.deb
+  - sudo dpkg -i libfaketime_0.9.7-3_amd64.deb
   - gem install bundler -v "~> 2.0"
+
+before_script:
+  - export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1
+  - export DONT_FAKE_MONOTONIC=1
+  - export FAKETIME_NO_CACHE=1

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ end
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake` to run the tests and code-style checks. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+Some tests require stubbing time with [libfaketime](https://github.com/wolfcw/libfaketime) in order to pass, otherwise they're skipped. You can install this library with your package manager. Follow libfaketime's instructions for your OS to preload the library before running the tests, and use the `DONT_FAKE_MONOTONIC=1 FAKETIME_NO_CACHE=1` options. E.g. when installed via homebrew on macOS:
+```shell
+DYLD_INSERT_LIBRARIES=/usr/local/Cellar/libfaketime/2.9.7_1/lib/faketime/libfaketime.1.dylib DYLD_FORCE_FLAT_NAMESPACE=1 DONT_FAKE_MONOTONIC=1 FAKETIME_NO_CACHE=1 bundle exec rspec
+```
+
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ### Commit message format

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,3 +50,21 @@ end
 def key_bytes(public_key)
   public_key.to_bn.to_s(2)
 end
+
+# Uses https://github.com/wolfcw/libfaketime/ to stub time. Unlike the Timecop gem this also works for C-extensions
+# such as OpenSSL. The library must be loaded per the libfaketime's README for the relevant operating system, and use
+# the DONT_FAKE_MONOTONIC=1 and FAKETIME_NO_CACHE=1 environment variables to work as expected for the test suite.
+def fake_time(time)
+  old_time = ENV["FAKETIME"]
+  new_time = time.strftime("%Y-%m-%d %H:%M:%S")
+
+  begin
+    ENV["FAKETIME"] = new_time
+    current = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+    skip("libfaketime not preloaded? current time is #{current} expected #{new_time}") if current != new_time
+
+    yield
+  ensure
+    ENV["FAKETIME"] = old_time
+  end
+end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -118,6 +118,8 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   end
 
   context "when android-safetynet attestation" do
+    around(:each) { |example| fake_time(Time.new(2018, 10, 6), &example) }
+
     let(:original_origin) { "http://localhost:3000" }
 
     let(:original_challenge) do
@@ -134,23 +136,14 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "verifies" do
-      # FIXME
-      pending "Test seed certificate expired, see https://github.com/cedarcode/webauthn-ruby/issues/105"
-
       expect(attestation_response.verify(original_challenge, original_origin)).to be_truthy
     end
 
     it "is valid" do
-      # FIXME
-      pending "Test seed certificate expired, see https://github.com/cedarcode/webauthn-ruby/issues/105"
-
       expect(attestation_response.valid?(original_challenge, original_origin)).to eq(true)
     end
 
     it "returns attestation info" do
-      # FIXME
-      pending "Test seed certificate expired, see https://github.com/cedarcode/webauthn-ruby/issues/105"
-
       # TODO: Remove the need for #valid? to be called first
       attestation_response.valid?(original_challenge, original_origin)
 


### PR DESCRIPTION
[libfaketime](https://github.com/wolfcw/libfaketime) allows us to stub time in OpenSSL. It is a bit harder to set up though, which is why I added some documentation and a hopefully helpful skip message.

On my macOS machine, everything succeeds by running:
`DYLD_INSERT_LIBRARIES=/usr/local/Cellar/libfaketime/2.9.7_1/lib/faketime/libfaketime.1.dylib DYLD_FORCE_FLAT_NAMESPACE=1 DONT_FAKE_MONOTONIC=1 FAKETIME_NO_CACHE=1 bundle exec rspec`

While a plain `bundle exec rspec` results in:
```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) WebAuthn::AuthenticatorAttestationResponse when android-safetynet attestation verifies
     # libfaketime not preloaded? current time is 2019-01-21 22:48:26 expected 2018-10-06 00:00:00
     Failure/Error: skip("libfaketime not preloaded? current time is #{current} expected #{new_time}") if current != new_time
       RSpec::Core::Pending::SkipDeclaredInExample
     # ./spec/spec_helper.rb:64:in `fake_time'
     # ./spec/webauthn/authenticator_attestation_response_spec.rb:121:in `block (3 levels) in <top (required)>'
```

Fix #105 