### PR TITLE
docs: remove TODO comments for attestation type and path

### DIFF
--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "returns attestation info" do
-      # TODO: Remove the need for #valid? to be called first
       attestation_response.valid?(original_challenge, original_origin)
 
       expect(attestation_response.attestation_type).to eq("Basic_or_AttCA")
@@ -105,7 +104,6 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "returns attestation info" do
-      # TODO: Remove the need for #valid? to be called first
       attestation_response.valid?(original_challenge, original_origin)
 
       expect(attestation_response.attestation_type).to eq("Self")
@@ -144,7 +142,6 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "returns attestation info" do
-      # TODO: Remove the need for #valid? to be called first
       attestation_response.valid?(original_challenge, original_origin)
 
       expect(attestation_response.attestation_type).to eq("Basic")


### PR DESCRIPTION
The W3C spec states at the end of every verification procedure for a attestation type:

> If successful, return implementation-specific values representing attestation type <x> and attestation trust path <y>

Thus the TODO comment makes no sense, we need to call `valid?` to make this data available