### PR TITLE
Add simple server to use with FIDO2 conformance test tool

### DIFF
--- a/spec/conformance/Gemfile
+++ b/spec/conformance/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 2.6.0"
+
+gem "byebug"
+gem "rack-contrib"
+gem "sinatra", "~> 2.0"
+gem "sinatra-contrib"
+gem "webauthn", path: File.join("..", "..")

--- a/spec/conformance/Gemfile.lock
+++ b/spec/conformance/Gemfile.lock
@@ -1,0 +1,59 @@
+PATH
+  remote: ../..
+  specs:
+    webauthn (1.12.0)
+      cbor (~> 0.5.9)
+      cose (~> 0.6.0)
+      jwt (>= 1.5, < 3.0)
+      openssl (~> 2.0)
+      securecompare (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backports (3.12.0)
+    byebug (11.0.0)
+    cbor (0.5.9.3)
+    cose (0.6.1)
+      cbor (~> 0.5.9)
+    ipaddr (1.2.2)
+    jwt (2.1.0)
+    multi_json (1.13.1)
+    mustermann (1.0.3)
+    openssl (2.1.2)
+      ipaddr
+    rack (2.0.6)
+    rack-contrib (2.1.0)
+      rack (~> 2.0)
+    rack-protection (2.0.5)
+      rack
+    securecompare (1.0.0)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    sinatra-contrib (2.0.5)
+      backports (>= 2.8.2)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.5)
+      sinatra (= 2.0.5)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.9)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  byebug
+  rack-contrib
+  sinatra (~> 2.0)
+  sinatra-contrib
+  webauthn!
+
+RUBY VERSION
+   ruby 2.6.1p33
+
+BUNDLED WITH
+   1.17.3

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -1,0 +1,21 @@
+# FIDO2 conformance test server
+
+This is a minimal server implementation for use with the FIDO2 Conformance Test Tool, which can be obtained after 
+registration at https://fidoalliance.org/certification/functional-certification/conformance/
+
+The code contained herein is _**not**_ representative of a production implementation of a WebAuthn relying party.
+
+## Usage
+
+Install dependencies using Bundler:
+```
+cd spec/conformance
+bundle install
+```
+
+Start the server:
+```
+bundle exec ruby server.rb
+```
+
+Configure the FIDO2 Test Tool to use the following server URL: `http://localhost:4567` and run any of the server tests.

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "webauthn"
+require "sinatra"
+require "rack/contrib"
+require "sinatra/cookies"
+require "byebug"
+
+use Rack::PostBodyContentTypeParser
+set show_exceptions: false
+
+RP_NAME = "webauthn-ruby #{WebAuthn::VERSION} conformance test server"
+
+ClientRequest =
+  Struct.new(:user_name, :display_name, :attestation, :authenticator_selection, :extensions, :credentials) do
+    @storage = {}
+
+    def self.find(user_name)
+      @storage.fetch(user_name)
+    end
+
+    def self.find_or_create(params)
+      @storage[params["username"]] ||= ClientRequest.new(
+        params["username"],
+        params["displayName"],
+        params["attestation"],
+        params["authenticatorSelection"],
+        params["extensions"] || { "example.extension": true },
+        []
+      )
+    end
+
+    def public_key_credential_descriptors
+      credentials.map { |credential| { id: credential[:credential_id], type: "public-key" } }
+    end
+  end
+
+post "/attestation/options" do
+  req = ClientRequest.find_or_create(params)
+  cookies["username"] = req.user_name
+
+  options = base64_credential_creation_options
+  options[:user][:name] = req.user_name
+  options[:user][:displayName] = req.display_name
+  options[:attestation] = req.attestation
+  options[:authenticatorSelection] = req.authenticator_selection
+  options[:extensions] = req.extensions
+  options[:excludeCredentials] = req.public_key_credential_descriptors
+
+  cookies["challenge"] = options[:challenge]
+  render_ok(options)
+end
+
+post "/attestation/result" do
+  attestation_object = Base64.urlsafe_decode64(params["response"]["attestationObject"])
+  client_data_json = Base64.urlsafe_decode64(params["response"]["clientDataJSON"])
+  attestation_response = WebAuthn::AuthenticatorAttestationResponse.new(
+    attestation_object: attestation_object,
+    client_data_json: client_data_json
+  )
+
+  original_challenge = Base64.urlsafe_decode64(cookies["challenge"])
+  original_origin = "http://localhost:#{settings.port}"
+  attestation_response.verify(original_challenge, original_origin)
+
+  req = ClientRequest.find(cookies["username"])
+  req.credentials << {
+    credential_id: Base64.urlsafe_encode64(attestation_response.credential.id, padding: false),
+    public_key: attestation_response.credential.public_key,
+  }
+
+  render_ok
+end
+
+post "/assertion/options" do
+  req = ClientRequest.find(cookies["username"])
+  options = base64_credential_request_options
+  options[:allowCredentials] = req.public_key_credential_descriptors
+  options[:extensions] = req.extensions
+  options[:userVerification] = params["userVerification"]
+
+  render_ok(options)
+end
+
+post "/assertion/result" do
+  credential_id = Base64.urlsafe_decode64(params["id"])
+  authenticator_data = Base64.urlsafe_decode64(params["response"]["authenticatorData"])
+  client_data_json = Base64.urlsafe_decode64(params["response"]["clientDataJSON"])
+  signature = Base64.urlsafe_decode64(params["response"]["signature"])
+  assertion_response = WebAuthn::AuthenticatorAssertionResponse.new(
+    credential_id: credential_id,
+    authenticator_data: authenticator_data,
+    client_data_json: client_data_json,
+    signature: signature
+  )
+
+  original_challenge = Base64.urlsafe_decode64(cookies["challenge"])
+  original_origin = "http://localhost:#{settings.port}"
+  allowed_credentials = ClientRequest.find(cookies["username"]).credentials
+  assertion_response.verify(original_challenge, original_origin, allowed_credentials: allowed_credentials)
+
+  render_ok
+end
+
+error 500 do
+  error = env["sinatra.error"]
+  render_error(<<~MSG)
+    #{error.class}: #{error.message}
+    #{error.backtrace.take(10).join("\n")}
+  MSG
+end
+
+private
+
+def render_ok(params = {})
+  JSON.dump({ status: "ok", errorMessage: "" }.merge!(params))
+end
+
+def render_error(message)
+  JSON.dump(status: "error", errorMessage: message)
+end
+
+def base64_credential_creation_options
+  options = WebAuthn.credential_creation_options
+  options[:rp][:name] = RP_NAME
+  options[:challenge] = Base64.urlsafe_encode64(options[:challenge], padding: false)
+  options
+end
+
+def base64_credential_request_options
+  options = WebAuthn.credential_request_options
+  options[:challenge] = Base64.urlsafe_encode64(options[:challenge], padding: false)
+  options
+end


### PR DESCRIPTION
For use with the tool available https://fidoalliance.org/certification/functional-certification/conformance/ 

Kept dependancies as simple as possible on purpose. I've spoken to the FIDO Alliance certification director at an event and she mentioned they test open source implementations too at interop events, assuming they've self-certified using the tool. Once the gem is able I don't want them to have to fight with C-extension compilation 😅 

Still a bunch of things to refactor and fix inside the server code, I'll start opening issues for things that need fixing inside the gem as I work on this as time permits. Currently we're at 112 passes and 41 failures on tool version 0.10.211.