### PR TITLE
Speed up secure compare

### DIFF
--- a/lib/webauthn/security_utils.rb
+++ b/lib/webauthn/security_utils.rb
@@ -10,8 +10,8 @@ module WebAuthn
     # The values are first processed by SHA256, so that we don't leak length info
     # via timing attacks.
     def secure_compare(first_string, second_string)
-      first_string_sha256 = ::Digest::SHA256.hexdigest(first_string)
-      second_string_sha256 = ::Digest::SHA256.hexdigest(second_string)
+      first_string_sha256 = ::Digest::SHA256.digest(first_string)
+      second_string_sha256 = ::Digest::SHA256.digest(second_string)
 
       SecureCompare.compare(first_string_sha256, second_string_sha256) && first_string == second_string
     end


### PR DESCRIPTION
Hex encoding is base 16 which makes the original input twice as big. We don't need to encode the SHA256 output bytes and the shorter output means we spend less time in `SecureCompare.compare`

Same as https://github.com/rails/rails/pull/35556