### PR TITLE
fix: verify U2F attested credential data AAGUID is zeroed out

### DIFF
--- a/lib/webauthn/attestation_statement/fido_u2f.rb
+++ b/lib/webauthn/attestation_statement/fido_u2f.rb
@@ -9,11 +9,13 @@ module WebAuthn
     class FidoU2f < Base
       VALID_ATTESTATION_CERTIFICATE_COUNT = 1
       VALID_ATTESTATION_CERTIFICATE_ALGORITHM = COSE::Algorithm.by_name("ES256")
+      VALID_ATTESTED_AAGUID = 0.chr * WebAuthn::AuthenticatorData::AttestedCredentialData::AAGUID_LENGTH
 
       def valid?(authenticator_data, client_data_hash)
         valid_format? &&
           valid_certificate_public_key? &&
           valid_credential_public_key?(authenticator_data.credential.public_key) &&
+          valid_aaguid?(authenticator_data.attested_credential_data.aaguid) &&
           valid_signature?(authenticator_data, client_data_hash) &&
           [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC_OR_ATTCA, [attestation_certificate]]
       end
@@ -49,6 +51,10 @@ module WebAuthn
 
       def raw_attestation_certificates
         statement["x5c"]
+      end
+
+      def valid_aaguid?(attested_credential_data_aaguid)
+        attested_credential_data_aaguid == VALID_ATTESTED_AAGUID
       end
 
       def valid_signature?(authenticator_data, client_data_hash)

--- a/lib/webauthn/fake_authenticator.rb
+++ b/lib/webauthn/fake_authenticator.rb
@@ -32,7 +32,7 @@ module WebAuthn
       attestation_object
     end
 
-    def get_assertion(rp_id:, client_data_hash:, user_present: true, user_verified: false)
+    def get_assertion(rp_id:, client_data_hash:, user_present: true, user_verified: false, aaguid: AAGUID)
       credential_options = credentials[rp_id]
 
       if credential_options
@@ -41,7 +41,8 @@ module WebAuthn
         authenticator_data = AuthenticatorData.new(
           rp_id_hash: hashed(rp_id),
           user_present: user_present,
-          user_verified: user_verified
+          user_verified: user_verified,
+          aaguid: aaguid,
         ).serialize
 
         signature = credential_key.sign("SHA256", authenticator_data + client_data_hash)

--- a/lib/webauthn/fake_authenticator/authenticator_data.rb
+++ b/lib/webauthn/fake_authenticator/authenticator_data.rb
@@ -7,12 +7,14 @@ require "securerandom"
 module WebAuthn
   class FakeAuthenticator
     class AuthenticatorData
-      def initialize(rp_id_hash:, credential: nil, sign_count: 0, user_present: true, user_verified: !user_present)
+      def initialize(rp_id_hash:, credential: nil, sign_count: 0, user_present: true, user_verified: !user_present,
+                     aaguid: WebAuthn::FakeAuthenticator::AAGUID)
         @rp_id_hash = rp_id_hash
         @credential = credential
         @sign_count = sign_count
         @user_present = user_present
         @user_verified = user_verified
+        @aaguid = aaguid
       end
 
       def serialize
@@ -45,7 +47,7 @@ module WebAuthn
       def attested_credential_data
         @attested_credential_data ||=
           if credential
-            WebAuthn::FakeAuthenticator::AAGUID +
+            @aaguid +
               [credential[:id].length].pack("n*") +
               credential[:id] +
               cose_credential_public_key

--- a/spec/webauthn/attestation_statement/fido_u2f_spec.rb
+++ b/spec/webauthn/attestation_statement/fido_u2f_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "FidoU2f attestation" do
       WebAuthn::FakeAuthenticator::AuthenticatorData.new(
         rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
         credential: { id: "0".b * 16, public_key: credential_public_key },
+        aaguid: WebAuthn::AttestationStatement::FidoU2f::VALID_ATTESTED_AAGUID
       ).serialize
     end
 
@@ -117,6 +118,20 @@ RSpec.describe "FidoU2f attestation" do
         it "fails" do
           expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
         end
+      end
+    end
+
+    context "when the AAGUID is invalid" do
+      let(:authenticator_data_bytes) do
+        WebAuthn::FakeAuthenticator::AuthenticatorData.new(
+          rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
+          credential: { id: "0".b * 16, public_key: credential_public_key },
+          aaguid: WebAuthn::FakeAuthenticator::AAGUID
+        ).serialize
+      end
+
+      it "fails" do
+        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
       end
     end
   end


### PR DESCRIPTION
The conformance test tool notified me of this (Server-ServerAuthenticatorAttestationResponse-Resp-8, test F-1). It used to be called out more clearly in the spec:
https://github.com/w3c/webauthn/pull/539/commits/4a376bf198f839abe123e5e32458c83d40b67f29 but that has been changed over time.

Now https://www.w3.org/TR/2019/PR-webauthn-20190117/#fido-u2f-attestation mentions only:
> Extract the claimed rpIdHash from authenticatorData, and the claimed credentialId and credentialPublicKey from authenticatorData.attestedCredentialData.

which is vague about what you're supposed to expect.

Fortunately we have https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#u2f-authenticatorMakeCredential-interoperability confirming the AAGUID should be initialized with 16 zeroes.

The _actual_ AAGUID for U2F authenticators lives in the certificates, similar to the packed attestation format, which we need for https://github.com/cedarcode/webauthn-ruby/issues/66