### PR TITLE
refactor: make required credentials creation options more explicit

### DIFF
--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -12,17 +12,15 @@ require "json"
 
 module WebAuthn
   CRED_PARAM_ES256 = { type: "public-key", alg: COSE::Algorithm.by_name("ES256").id }.freeze
-  RP_NAME = "web-server"
-  USER_ID = "1"
-  USER_NAME = "web-user"
   TYPES = { create: "webauthn.create", get: "webauthn.get" }.freeze
 
-  def self.credential_creation_options
+  # TODO: make keyword arguments mandatory in next major version
+  def self.credential_creation_options(rp_name: "web-server", user_name: "web-user", display_name: "web-user", id: "1")
     {
       challenge: challenge,
       pubKeyCredParams: [CRED_PARAM_ES256],
-      rp: { name: RP_NAME },
-      user: { name: USER_NAME, displayName: USER_NAME, id: USER_ID }
+      rp: { name: rp_name },
+      user: { name: user_name, displayName: display_name, id: id }
     }
   end
 


### PR DESCRIPTION
These fields are required by the spec, they have meaning in how and when they should be used: https://www.w3.org/TR/2019/PR-webauthn-20190117/#dictionary-pkcredentialentity

I think current the defaults are not helpful for users of the gem since they may be shown by the browser in the future. If this happens, the unchanged defaults may lead to authentication prompts like:
> Scan fingerprint to authenticate as web-user for web-server

To not break backwards compatibility while making the need for explicit configuration more obvious, I've made the keyword arguments optional for now with a note to change this for version 2.0.