### PR TITLE
refactor: draw an abstraction line between WebAuthn and AndroidSafetynet's AttestationResponse

### DIFF
--- a/lib/android_safetynet/attestation_response.rb
+++ b/lib/android_safetynet/attestation_response.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "jwt"
+
+module AndroidSafetynet
+  # Decoupled from WebAuthn, candidate for extraction
+  # Reference: https://developer.android.com/training/safetynet/attestation.html
+  class AttestationResponse
+    class VerificationError < StandardError; end
+    class LeafCertificateSubjectError < VerificationError; end
+    class NonceMismatchError < VerificationError; end
+    class SignatureError < VerificationError; end
+    class ResponseMissingError < VerificationError; end
+
+    CERTIRICATE_CHAIN_HEADER = "x5c"
+    VALID_SUBJECT_HOSTNAME = "attest.android.com"
+    HEADERS_POSITION = 1
+    PAYLOAD_POSITION = 0
+
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    def verify(nonce)
+      if response
+        valid_nonce?(nonce) || raise(NonceMismatchError)
+        valid_attestation_domain? || raise(LeafCertificateSubjectError)
+        valid_signature? || raise(SignatureError)
+      else
+        raise(ResponseMissingError)
+      end
+    end
+
+    def cts_profile_match?
+      payload["ctsProfileMatch"]
+    end
+
+    def certificate_chain
+      @certificate_chain ||= headers[CERTIRICATE_CHAIN_HEADER].map do |cert|
+        OpenSSL::X509::Certificate.new(Base64.strict_decode64(cert))
+      end
+    end
+
+    private
+
+    def valid_nonce?(nonce)
+      payload["nonce"] == nonce
+    end
+
+    def valid_attestation_domain?
+      common_name = leaf_certificate&.subject&.to_a&.assoc('CN')
+
+      if common_name
+        common_name[1] == VALID_SUBJECT_HOSTNAME
+      end
+    end
+
+    def valid_signature?
+      JWT.decode(response, leaf_certificate.public_key, true, algorithms: algorithm_for(leaf_certificate.public_key))
+    rescue JWT::VerificationError
+      false
+    end
+
+    def algorithm_for(public_key)
+      case public_key
+      when OpenSSL::PKey::RSA
+        "RS256"
+      when OpenSSL::PKey::EC, OpenSSL::PKey::EC::Point
+        "ES256"
+      else
+        raise "Unsupported algorithm"
+      end
+    end
+
+    def leaf_certificate
+      certificate_chain[0]
+    end
+
+    def headers
+      jws_parts[HEADERS_POSITION]
+    end
+
+    def payload
+      jws_parts[PAYLOAD_POSITION]
+    end
+
+    def jws_parts
+      @jws_parts ||= JWT.decode(response, nil, false)
+    end
+  end
+end

--- a/spec/android_safetynet/attestation_response_spec.rb
+++ b/spec/android_safetynet/attestation_response_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "android_safetynet/attestation_response"
+require "jwt"
+require "openssl"
+
+RSpec.describe "AttestationResponse" do
+  context "#verify" do
+    let(:attestation_response) { AndroidSafetynet::AttestationResponse.new(response) }
+
+    let(:response) do
+      JWT.encode(
+        payload,
+        attestation_key,
+        "ES256",
+        x5c: [Base64.strict_encode64(leaf_certificate)]
+      )
+    end
+
+    let(:payload) { { nonce: nonce } }
+    let(:attestation_key) { OpenSSL::PKey::EC.new("prime256v1").generate_key }
+
+    let(:leaf_certificate) do
+      certificate = OpenSSL::X509::Certificate.new
+      certificate.subject = OpenSSL::X509::Name.new([["CN", leaf_certificate_subject_common_name]])
+      certificate.not_before = Time.now
+      certificate.not_after = Time.now + 60
+      certificate.public_key = attestation_key
+
+      certificate.sign(attestation_key, OpenSSL::Digest::SHA256.new)
+
+      certificate.to_der
+    end
+
+    let(:leaf_certificate_subject_common_name) { "attest.android.com" }
+    let(:nonce) { rand(16).to_s }
+
+    it "returns true if everything's in place" do
+      expect(attestation_response.verify(nonce)).to be_truthy
+    end
+
+    context "when nonce don't match with the one in the response" do
+      it "fails" do
+        expect {
+          attestation_response.verify(nonce + "something else")
+        }.to raise_error(AndroidSafetynet::AttestationResponse::NonceMismatchError)
+      end
+    end
+
+    context "when response is nil" do
+      let(:response) { nil }
+
+      it "fails" do
+        expect {
+          attestation_response.verify(nonce)
+        }.to raise_error(AndroidSafetynet::AttestationResponse::ResponseMissingError)
+      end
+    end
+
+    context "when the certificate chain is invalid" do
+      context "because leaf certificate issuer hostmane is invalid" do
+        let(:leaf_certificate_subject_common_name) { "notattest.android.com" }
+
+        it "fails" do
+          expect {
+            attestation_response.verify(nonce)
+          }.to raise_error(AndroidSafetynet::AttestationResponse::LeafCertificateSubjectError)
+        end
+      end
+    end
+
+    context "when the signature is invalid" do
+      context "because it was signed with a different key" do
+        let(:response) do
+          JWT.encode(
+            payload,
+            OpenSSL::PKey::EC.new("prime256v1").generate_key,
+            "ES256",
+            x5c: [Base64.strict_encode64(leaf_certificate)]
+          )
+        end
+
+        it "fails" do
+          expect {
+            attestation_response.verify(nonce)
+          }.to raise_error(AndroidSafetynet::AttestationResponse::SignatureError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
in part helps with #140 