### PR TITLE
refactor: make challenge/origin arguments less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ attestation_response = WebAuthn::AuthenticatorAttestationResponse.new(
 
 # This value needs to match `window.location.origin` evaluated by
 # the User Agent as part of the verification phase.
-original_origin = "https://www.example.com"
+expected_origin = "https://www.example.com"
 
-# In the case that a Relying Party ID (https://www.w3.org/TR/webauthn/#relying-party-identifier) different from `original_origin` was used on
+# In the case that a Relying Party ID (https://www.w3.org/TR/webauthn/#relying-party-identifier) different from `expected_origin` was used on
 # `navigator.credentials.create`, it needs to specified for verification.
 # Otherwise, you can ignore passing in this value to the `verify` method below.
 rp_id = "example.com"
 
 begin
-  attestation_response.verify(original_challenge, original_origin, rp_id: rp_id)
+  attestation_response.verify(expected_challenge, expected_origin, rp_id: rp_id)
 
   # 1. Register the new user and
   # 2. Keep Credential ID and Credential Public Key under storage
@@ -160,9 +160,9 @@ assertion_response = WebAuthn::AuthenticatorAssertionResponse.new(
 
 # This value needs to match `window.location.origin` evaluated by
 # the User Agent as part of the verification phase.
-original_origin = "https://www.example.com"
+expected_origin = "https://www.example.com"
 
-# In the case that a Relying Party ID (https://www.w3.org/TR/webauthn/#relying-party-identifier) different from `original_origin` was used on
+# In the case that a Relying Party ID (https://www.w3.org/TR/webauthn/#relying-party-identifier) different from `expected_origin` was used on
 # `navigator.credentials.get`, it needs to be specified for verification.
 # Otherwise, you can ignore passing in this value to the `verify` method below.`
 rp_id = "example.com"
@@ -175,7 +175,7 @@ allowed_credential = {
 }
 
 begin
-  assertion_response.verify(original_challenge, original_origin, allowed_credentials: [allowed_credential], rp_id: rp_id)
+  assertion_response.verify(expected_challenge, expected_origin, allowed_credentials: [allowed_credential], rp_id: rp_id)
 
   # Sign in the user
 rescue WebAuthn::VerificationError => e

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -18,8 +18,8 @@ module WebAuthn
       @signature = signature
     end
 
-    def verify(original_challenge, original_origin, allowed_credentials:, rp_id: nil)
-      super(original_challenge, original_origin, rp_id: rp_id)
+    def verify(expected_challenge, expected_origin, allowed_credentials:, rp_id: nil)
+      super(expected_challenge, expected_origin, rp_id: rp_id)
 
       verify_item(:credential, allowed_credentials)
       verify_item(:signature, credential_cose_key(allowed_credentials))

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -21,7 +21,7 @@ module WebAuthn
       @attestation_object = attestation_object
     end
 
-    def verify(original_challenge, original_origin, rp_id: nil)
+    def verify(expected_challenge, expected_origin, rp_id: nil)
       super
 
       verify_item(:attestation_statement)

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -18,13 +18,13 @@ module WebAuthn
       @client_data_json = client_data_json
     end
 
-    def verify(original_challenge, original_origin, rp_id: nil)
+    def verify(expected_challenge, expected_origin, rp_id: nil)
       verify_item(:type)
       verify_item(:token_binding)
-      verify_item(:challenge, original_challenge)
-      verify_item(:origin, original_origin)
+      verify_item(:challenge, expected_challenge)
+      verify_item(:origin, expected_origin)
       verify_item(:authenticator_data)
-      verify_item(:rp_id, rp_id || rp_id_from_origin(original_origin))
+      verify_item(:rp_id, rp_id || rp_id_from_origin(expected_origin))
       verify_item(:user_presence)
 
       true
@@ -62,12 +62,12 @@ module WebAuthn
       client_data.valid_token_binding_format?
     end
 
-    def valid_challenge?(original_challenge)
-      WebAuthn::SecurityUtils.secure_compare(Base64.urlsafe_decode64(client_data.challenge), original_challenge)
+    def valid_challenge?(expected_challenge)
+      WebAuthn::SecurityUtils.secure_compare(Base64.urlsafe_decode64(client_data.challenge), expected_challenge)
     end
 
-    def valid_origin?(original_origin)
-      client_data.origin == original_origin
+    def valid_origin?(expected_origin)
+      client_data.origin == expected_origin
     end
 
     def valid_rp_id?(rp_id)
@@ -82,8 +82,8 @@ module WebAuthn
       authenticator_data.user_flagged?
     end
 
-    def rp_id_from_origin(original_origin)
-      URI.parse(original_origin).host
+    def rp_id_from_origin(expected_origin)
+      URI.parse(expected_origin).host
     end
 
     def type

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -59,9 +59,9 @@ post "/attestation/result" do
     client_data_json: client_data_json
   )
 
-  original_challenge = Base64.urlsafe_decode64(cookies["challenge"])
-  original_origin = "http://localhost:#{settings.port}"
-  attestation_response.verify(original_challenge, original_origin)
+  expected_challenge = Base64.urlsafe_decode64(cookies["challenge"])
+  expected_origin = "http://localhost:#{settings.port}"
+  attestation_response.verify(expected_challenge, expected_origin)
 
   req = ClientRequest.find(cookies["username"])
   req.credentials << {
@@ -94,10 +94,10 @@ post "/assertion/result" do
     signature: signature
   )
 
-  original_challenge = Base64.urlsafe_decode64(cookies["challenge"])
-  original_origin = "http://localhost:#{settings.port}"
+  expected_challenge = Base64.urlsafe_decode64(cookies["challenge"])
+  expected_origin = "http://localhost:#{settings.port}"
   allowed_credentials = ClientRequest.find(cookies["username"]).credentials
-  assertion_response.verify(original_challenge, original_origin, allowed_credentials: allowed_credentials)
+  assertion_response.verify(expected_challenge, expected_origin, allowed_credentials: allowed_credentials)
 
   render_ok
 end


### PR DESCRIPTION
Motivated by conversation in #150.

"original" is confusing here. It was intended to mean the original value when the ceremony started, but it might confuse by lead to think that during the Authentication ceremony, this is asking for the original value from the Registration, which is not what we want.

I considered naming them just `challenge` and `origin` , but I ended up with `expected_challenge` and `expected_origin`, because I was afraid that reading `response.verify(challenge, origin)` could lead to the potential confusion that this arguments are the ones being verified for correctness, when they are actually the expected values, and the things being verified are the ones "inside" the response.

However, not strong on that if someone else prefers shorter names.