### PR TITLE
Change origin/RP ID checks to align better with the spec.

### DIFF
--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -18,7 +18,7 @@ module WebAuthn
       @signature = signature
     end
 
-    def verify(expected_challenge, expected_origin, allowed_credentials:, rp_id: nil)
+    def verify(expected_challenge, expected_origin=nil, allowed_credentials:, rp_id: nil)
       super(expected_challenge, expected_origin, rp_id: rp_id)
 
       verify_item(:credential, allowed_credentials)

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -21,7 +21,7 @@ module WebAuthn
       @attestation_object = attestation_object
     end
 
-    def verify(expected_challenge, expected_origin, rp_id: nil)
+    def verify(expected_challenge, expected_origin=nil, rp_id: nil)
       super
 
       verify_item(:attestation_statement)


### PR DESCRIPTION
- Rename the `original_origin` parameter to `current_origin`.
- Make the `current_origin` parameter optional by defaulting to `nil`
- Verify the signature origin against the RP ID.

Addresses issue #150.

--------

This is an attempt to preserve backwards compatibility, while:
- changing the checks to be against the RP ID, and
- Making it possible to pass just the RP ID (without the current origin).