### PR TITLE
feat: let RP accept RSA credentials as a second option by default

### DIFF
--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -11,7 +11,12 @@ require "securerandom"
 require "json"
 
 module WebAuthn
-  CRED_PARAM_ES256 = { type: "public-key", alg: COSE::Algorithm.by_name("ES256").id }.freeze
+  DEFAULT_ALGORITHMS = ["ES256", "RS256"].freeze
+
+  DEFAULT_PUB_KEY_CRED_PARAMS = DEFAULT_ALGORITHMS.map do |alg_name|
+    { type: "public-key", alg: COSE::Algorithm.by_name(alg_name).id }
+  end.freeze
+
   TYPES = { create: "webauthn.create", get: "webauthn.get" }.freeze
 
   # TODO: make keyword arguments mandatory in next major version
@@ -23,7 +28,7 @@ module WebAuthn
   )
     {
       challenge: challenge,
-      pubKeyCredParams: [CRED_PARAM_ES256],
+      pubKeyCredParams: DEFAULT_PUB_KEY_CRED_PARAMS,
       rp: { name: rp_name },
       user: { name: user_name, displayName: display_name, id: user_id }
     }

--- a/spec/webauthn_spec.rb
+++ b/spec/webauthn_spec.rb
@@ -17,8 +17,11 @@ RSpec.describe WebAuthn do
     end
 
     it "has public key params" do
-      expect(@credential_creation_options[:pubKeyCredParams][0][:type]).to eq("public-key")
-      expect(@credential_creation_options[:pubKeyCredParams][0][:alg]).to eq(-7)
+      params = @credential_creation_options[:pubKeyCredParams]
+
+      expect(params.size).to eq(2)
+      expect(params).to include(type: "public-key", alg: -7)
+      expect(params).to include(type: "public-key", alg: -257)
     end
 
     it "has relying party info" do


### PR DESCRIPTION
Follow up from #163 

Addresses https://github.com/cedarcode/webauthn-ruby/commit/1514afbf07f140c5f7cf532bb0fc220db0545dcb#r33251669