### PR TITLE
WIP: Improved gem public API

### DIFF
--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "webauthn/authenticator_attestation_response"
-require "webauthn/authenticator_assertion_response"
 require "webauthn/configuration"
+require "webauthn/credential"
 require "webauthn/credential_creation_options"
 require "webauthn/credential_request_options"
 require "webauthn/version"

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -8,12 +8,20 @@ require "webauthn/authenticator_data"
 require "webauthn/authenticator_response"
 require "webauthn/attestation_statement"
 require "webauthn/client_data"
+require "webauthn/client_utils"
 
 module WebAuthn
   class AttestationStatementVerificationError < VerificationError; end
 
   class AuthenticatorAttestationResponse < AuthenticatorResponse
     attr_reader :attestation_type, :attestation_trust_path
+
+    def self.from_json(json)
+      new(
+        attestation_object: WebAuthn::ClientUtils.decode(json["attestationObject"]),
+        client_data_json: WebAuthn::ClientUtils.decode(json["clientDataJSON"])
+      )
+    end
 
     def initialize(attestation_object:, **options)
       super(options)

--- a/lib/webauthn/client_utils.rb
+++ b/lib/webauthn/client_utils.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module WebAuthn
+  module ClientUtils
+    def self.encode(data)
+      # TODO: Make this configurable so users can choose to use regular Base64
+      # in the front-end instead of being forced to use URL-safe Base64
+      Base64.urlsafe_encode64(data, padding: false)
+    end
+
+    def self.decode(data)
+      # TODO: Make this configurable so users can choose to use regular Base64
+      # in the front-end instead of being forced to use URL-safe Base64
+      Base64.urlsafe_decode64(data)
+    end
+  end
+end

--- a/lib/webauthn/credential.rb
+++ b/lib/webauthn/credential.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "webauthn/authenticator_assertion_response"
+require "webauthn/authenticator_attestation_response"
+require "webauthn/client_utils"
+
+module WebAuthn
+  class Credential
+    def self.from_json(json)
+      id = WebAuthn::ClientUtils.decode(json["id"])
+      response_json = json["response"]
+
+      response =
+        if response_json["attestationObject"]
+          AuthenticatorAttestationResponse.from_json(response_json)
+        elsif response_json["signature"]
+          AuthenticatorAssertionResponse.from_json(response_json, id)
+        else
+          raise "invalid response"
+        end
+
+      new(id: id, response: response)
+    end
+
+    attr_reader :id, :response
+
+    def initialize(id:, response:)
+      @id = id
+      @response = response
+    end
+
+    def verify(expected_challenge, public_key = nil)
+      case response
+      when AuthenticatorAttestationResponse
+        response.verify(expected_challenge)
+      when AuthenticatorAssertionResponse
+        response.verify(expected_challenge, allowed_credentials: [{ id: id, public_key: public_key }])
+      end
+    end
+
+    def public_key
+      # Verify first?
+      response.credential.public_key
+    end
+  end
+end

--- a/lib/webauthn/credential.rb
+++ b/lib/webauthn/credential.rb
@@ -6,7 +6,13 @@ require "webauthn/client_utils"
 
 module WebAuthn
   class Credential
+    VALID_TYPE = "public-key"
+
     def self.from_json(json)
+      if json["type"] != VALID_TYPE
+        raise "invalid credential type"
+      end
+
       id = WebAuthn::ClientUtils.decode(json["id"])
       response_json = json["response"]
 

--- a/spec/webauthn/credential_spec.rb
+++ b/spec/webauthn/credential_spec.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# TODO: Write tests


### PR DESCRIPTION
Goals:
* providing better integration with WebAuthn client by (en|de)coding json and base64 transparently
* better match the [`PublicKeyCredential`](https://www.w3.org/TR/webauthn/#iface-pkcredential) interface
* being less confusing for gem users by just focusing and exposing the credential interface
* less user exposure to unnecessary internal RP operation details and terms, e.g. AuthenticationAttestationResponse or AuthenticatorAssertionResponse.

Closes:

* #87 
* #173
* #185 

Pending:

* [x] Implement from_json for attestation
* [x] Implmenet from_json for assertion
* [ ] Implement create_options
* [ ] Implement get_options
* [ ] Test coverage

