### PR TITLE
Add support for RSA Probabilistic Signature Scheme with SHA256

### DIFF
--- a/lib/cose/algorithm.rb
+++ b/lib/cose/algorithm.rb
@@ -27,5 +27,6 @@ module COSE
 end
 
 COSE::Algorithm.register(-7, "ES256", "SHA256", COSE::Key::EC2::KTY_EC2, "prime256v1")
+COSE::Algorithm.register(-37, "PS256", "SHA256", COSE::Key::RSA::KTY_RSA)
 COSE::Algorithm.register(-257, "RS256", "SHA256", COSE::Key::RSA::KTY_RSA)
 COSE::Algorithm.register(-65535, "RS1", "SHA1", COSE::Key::RSA::KTY_RSA)

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -10,7 +10,7 @@ module WebAuthn
   end
 
   class Configuration
-    DEFAULT_ALGORITHMS = ["ES256", "RS256"].freeze
+    DEFAULT_ALGORITHMS = ["ES256", "PS256", "RS256"].freeze
 
     attr_accessor :algorithms
     attr_accessor :origin

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -10,7 +10,11 @@ module WebAuthn
   end
 
   class Configuration
-    DEFAULT_ALGORITHMS = ["ES256", "PS256", "RS256"].freeze
+    def self.if_pss_supported(algorithm)
+      OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss) ? algorithm : nil
+    end
+
+    DEFAULT_ALGORITHMS = ["ES256", if_pss_supported("PS256"), "RS256"].compact.freeze
 
     attr_accessor :algorithms
     attr_accessor :origin

--- a/lib/webauthn/signature_verifier.rb
+++ b/lib/webauthn/signature_verifier.rb
@@ -23,7 +23,12 @@ module WebAuthn
     end
 
     def verify(signature, verification_data)
-      public_key.verify(cose_algorithm.hash, signature, verification_data)
+      if rsa_pss?
+        public_key.verify_pss(cose_algorithm.hash, signature, verification_data,
+                              salt_length: :digest, mgf1_hash: cose_algorithm.hash)
+      else
+        public_key.verify(cose_algorithm.hash, signature, verification_data)
+      end
     end
 
     private
@@ -37,6 +42,10 @@ module WebAuthn
       else
         COSE::Algorithm.find(algorithm)
       end
+    end
+
+    def rsa_pss?
+      cose_algorithm.name.start_with?("PS")
     end
 
     def validate

--- a/spec/conformance/Gemfile.lock
+++ b/spec/conformance/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       cbor (~> 0.5.9)
       cose (~> 0.7.0)
       jwt (>= 1.5, < 3.0)
-      openssl (~> 2.0)
+      openssl (~> 2.1)
       securecompare (~> 1.0)
 
 GEM
@@ -19,7 +19,7 @@ GEM
     cose (0.7.0)
       cbor (~> 0.5.9)
     ipaddr (1.2.2)
-    jwt (2.1.0)
+    jwt (2.2.1)
     multi_json (1.13.1)
     mustermann (1.0.3)
     openssl (2.1.2)

--- a/spec/conformance/Gemfile.lock
+++ b/spec/conformance/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       cbor (~> 0.5.9)
       cose (~> 0.7.0)
       jwt (>= 1.5, < 3.0)
-      openssl (~> 2.1)
+      openssl (~> 2.0)
       securecompare (~> 1.0)
 
 GEM

--- a/spec/webauthn/credential_creation_options_spec.rb
+++ b/spec/webauthn/credential_creation_options_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe WebAuthn::CredentialCreationOptions do
     it "has default public key params" do
       params = creation_options.pub_key_cred_params
 
-      expect(params.class).to eq(Array)
-      expect(params.length).to eq(2)
-
-      expect(params).to include(type: "public-key", alg: -7)
-      expect(params).to include(type: "public-key", alg: -257)
+      expect(params).to match_array([
+                                      { type: "public-key", alg: -7 },
+                                      { type: "public-key", alg: -37 },
+                                      { type: "public-key", alg: -257 },
+                                    ])
     end
 
     context "when extra alg added" do
@@ -33,12 +33,12 @@ RSpec.describe WebAuthn::CredentialCreationOptions do
       it "is added to public key params" do
         params = creation_options.pub_key_cred_params
 
-        expect(params.class).to eq(Array)
-        expect(params.length).to eq(3)
-
-        expect(params).to include(type: "public-key", alg: -7)
-        expect(params).to include(type: "public-key", alg: -257)
-        expect(params).to include(type: "public-key", alg: -65535)
+        expect(params).to match_array([
+                                        { type: "public-key", alg: -7 },
+                                        { type: "public-key", alg: -37 },
+                                        { type: "public-key", alg: -257 },
+                                        { type: "public-key", alg: -65535 },
+                                      ])
       end
     end
   end

--- a/spec/webauthn/credential_creation_options_spec.rb
+++ b/spec/webauthn/credential_creation_options_spec.rb
@@ -18,11 +18,20 @@ RSpec.describe WebAuthn::CredentialCreationOptions do
     it "has default public key params" do
       params = creation_options.pub_key_cred_params
 
-      expect(params).to match_array([
-                                      { type: "public-key", alg: -7 },
-                                      { type: "public-key", alg: -37 },
-                                      { type: "public-key", alg: -257 },
-                                    ])
+      array = if OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)
+                [
+                  { type: "public-key", alg: -7 },
+                  { type: "public-key", alg: -37 },
+                  { type: "public-key", alg: -257 },
+                ]
+              else
+                [
+                  { type: "public-key", alg: -7 },
+                  { type: "public-key", alg: -257 },
+                ]
+              end
+
+      expect(params).to match_array(array)
     end
 
     context "when extra alg added" do
@@ -33,12 +42,22 @@ RSpec.describe WebAuthn::CredentialCreationOptions do
       it "is added to public key params" do
         params = creation_options.pub_key_cred_params
 
-        expect(params).to match_array([
-                                        { type: "public-key", alg: -7 },
-                                        { type: "public-key", alg: -37 },
-                                        { type: "public-key", alg: -257 },
-                                        { type: "public-key", alg: -65535 },
-                                      ])
+        array = if OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)
+                  [
+                    { type: "public-key", alg: -7 },
+                    { type: "public-key", alg: -37 },
+                    { type: "public-key", alg: -257 },
+                    { type: "public-key", alg: -65535 },
+                  ]
+                else
+                  [
+                    { type: "public-key", alg: -7 },
+                    { type: "public-key", alg: -257 },
+                    { type: "public-key", alg: -65535 },
+                  ]
+                end
+
+        expect(params).to match_array(array)
       end
     end
   end

--- a/spec/webauthn/signature_verifier_spec.rb
+++ b/spec/webauthn/signature_verifier_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe "SignatureVerifier" do
   end
 
   context "PS256" do
+    before do
+      unless OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)
+        skip "Ruby OpenSSL gem #{OpenSSL::VERSION} do not support RSASSA-PSS"
+      end
+    end
+
     let(:signature) { key.sign_pss(hash_algorithm, to_be_signed, salt_length: :digest, mgf1_hash: hash_algorithm) }
     let(:algorithm_id) { -37 }
     let(:public_key) { key.public_key }
@@ -173,6 +179,12 @@ RSpec.describe "SignatureVerifier" do
     end
 
     context "when it was signed with the same key but using PSS" do
+      before do
+        unless OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)
+          skip "Ruby OpenSSL gem #{OpenSSL::VERSION} do not support RSASSA-PSS"
+        end
+      end
+
       let(:signature) { key.sign_pss(hash_algorithm, to_be_signed, salt_length: :digest, mgf1_hash: hash_algorithm) }
 
       it "fails" do

--- a/spec/webauthn/signature_verifier_spec.rb
+++ b/spec/webauthn/signature_verifier_spec.rb
@@ -62,6 +62,76 @@ RSpec.describe "SignatureVerifier" do
     end
   end
 
+  context "PS256" do
+    let(:signature) { key.sign_pss(hash_algorithm, to_be_signed, salt_length: :digest, mgf1_hash: hash_algorithm) }
+    let(:algorithm_id) { -37 }
+    let(:public_key) { key.public_key }
+    let(:key) { OpenSSL::PKey::RSA.new(2048) }
+
+    it "works" do
+      expect(verifier.verify(signature, to_be_signed)).to be_truthy
+    end
+
+    context "when it was signed using a different hash algorithm" do
+      let(:hash_algorithm) { "SHA1" }
+
+      it "fails" do
+        expect(verifier.verify(signature, to_be_signed)).to be_falsy
+      end
+    end
+
+    context "when the masking generation function was using a different hash algorithm" do
+      let(:signature) { key.sign_pss(hash_algorithm, to_be_signed, salt_length: :digest, mgf1_hash: "SHA1") }
+
+      it "fails" do
+        expect(verifier.verify(signature, to_be_signed)).to be_falsy
+      end
+    end
+
+    context "when salt length is not equal to the hash function output" do
+      let(:signature) { key.sign_pss(hash_algorithm, to_be_signed, salt_length: :max, mgf1_hash: hash_algorithm) }
+
+      it "fails" do
+        expect(verifier.verify(signature, to_be_signed)).to be_falsy
+      end
+    end
+
+    context "when it is valid but in an EC context" do
+      let(:public_key) do
+        pkey = OpenSSL::PKey::EC.new("prime256v1")
+        pkey.public_key = key.public_key
+
+        pkey
+      end
+
+      let(:key) { OpenSSL::PKey::EC.new("prime256v1").generate_key }
+
+      it "fails" do
+        expect { verifier.verify(signature, to_be_signed) }.to raise_error("Incompatible algorithm and key")
+      end
+    end
+
+    context "when it was signed with a different key" do
+      let(:signature) do
+        OpenSSL::PKey::RSA
+          .new(2048)
+          .sign_pss(hash_algorithm, to_be_signed, salt_length: :digest, mgf1_hash: hash_algorithm)
+      end
+
+      it "fails" do
+        expect(verifier.verify(signature, to_be_signed)).to be_falsy
+      end
+    end
+
+    context "when it was signed with the same key but using PKCS1-v1_5 padding" do
+      let(:signature) { key.sign(hash_algorithm, to_be_signed) }
+
+      it "fails" do
+        expect(verifier.verify(signature, to_be_signed)).to be_falsy
+      end
+    end
+  end
+
   context "RS256" do
     let(:algorithm_id) { -257 }
     let(:public_key) { key.public_key }
@@ -96,6 +166,14 @@ RSpec.describe "SignatureVerifier" do
 
     context "when it was signed with a different key" do
       let(:signature) { OpenSSL::PKey::RSA.new(2048).sign(hash_algorithm, to_be_signed) }
+
+      it "fails" do
+        expect(verifier.verify(signature, to_be_signed)).to be_falsy
+      end
+    end
+
+    context "when it was signed with the same key but using PSS" do
+      let(:signature) { key.sign_pss(hash_algorithm, to_be_signed, salt_length: :digest, mgf1_hash: hash_algorithm) }
 
       it "fails" do
         expect(verifier.verify(signature, to_be_signed)).to be_falsy

--- a/spec/webauthn_spec.rb
+++ b/spec/webauthn_spec.rb
@@ -19,11 +19,20 @@ RSpec.describe WebAuthn do
     it "has public key params" do
       params = @credential_creation_options[:pubKeyCredParams]
 
-      expect(params).to match_array([
-                                      { type: "public-key", alg: -7 },
-                                      { type: "public-key", alg: -37 },
-                                      { type: "public-key", alg: -257 },
-                                    ])
+      array = if OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss)
+                [
+                  { type: "public-key", alg: -7 },
+                  { type: "public-key", alg: -37 },
+                  { type: "public-key", alg: -257 },
+                ]
+              else
+                [
+                  { type: "public-key", alg: -7 },
+                  { type: "public-key", alg: -257 },
+                ]
+              end
+
+      expect(params).to match_array(array)
     end
 
     it "has user info" do

--- a/spec/webauthn_spec.rb
+++ b/spec/webauthn_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe WebAuthn do
     it "has public key params" do
       params = @credential_creation_options[:pubKeyCredParams]
 
-      expect(params.size).to eq(2)
-      expect(params).to include(type: "public-key", alg: -7)
-      expect(params).to include(type: "public-key", alg: -257)
+      expect(params).to match_array([
+                                      { type: "public-key", alg: -7 },
+                                      { type: "public-key", alg: -37 },
+                                      { type: "public-key", alg: -257 },
+                                    ])
     end
 
     it "has user info" do

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "cose", "~> 0.7.0"
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
-  spec.add_dependency "openssl", "~> 2.0"
+  spec.add_dependency "openssl", "~> 2.1"
   spec.add_dependency "securecompare", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "cose", "~> 0.7.0"
   spec.add_dependency "jwt", [">= 1.5", "< 3.0"]
-  spec.add_dependency "openssl", "~> 2.1"
+  spec.add_dependency "openssl", "~> 2.0"
   spec.add_dependency "securecompare", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"


### PR DESCRIPTION
`verify_pss` is available since OpenSSL gem 2.1: https://github.com/ruby/openssl/pull/169

Per https://tools.ietf.org/html/rfc8230#section-2
- the same hash function for hashing and mask generation function is used
- the salt length must be the same as the hash function output

Prioritize PS256 over RS256 per https://tools.ietf.org/html/rfc8017#section-8:
> Although no attacks are known against RSASSA-PKCS1-v1_5, in the interest of increased robustness, RSASSA-PSS is REQUIRED in new applications. RSASSA-PKCS1-v1_5 is included only for compatibility with existing applications.

Refactored the tests a little to use RSpec's array matcherfor credential creation options.