### PR TITLE
Silence warnings about using 'raise_error' without providing a specific error

### DIFF
--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "PublicKeyCredential" do
       let(:type) { nil }
 
       it "fails" do
-        expect { public_key_credential.verify(challenge) }.to raise_error
+        expect { public_key_credential.verify(challenge) }.to raise_error(RuntimeError)
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe "PublicKeyCredential" do
       let(:type) { "password" }
 
       it "fails" do
-        expect { public_key_credential.verify(challenge) }.to raise_error
+        expect { public_key_credential.verify(challenge) }.to raise_error(RuntimeError)
       end
     end
   end
@@ -66,7 +66,7 @@ RSpec.describe "PublicKeyCredential" do
       let(:id) { nil }
 
       it "fails" do
-        expect { public_key_credential.verify(challenge) }.to raise_error
+        expect { public_key_credential.verify(challenge) }.to raise_error(RuntimeError)
       end
     end
 
@@ -74,14 +74,14 @@ RSpec.describe "PublicKeyCredential" do
       let(:id) { Base64.urlsafe_encode64(raw_id + "a") }
 
       it "fails" do
-        expect { public_key_credential.verify(challenge) }.to raise_error
+        expect { public_key_credential.verify(challenge) }.to raise_error(RuntimeError)
       end
     end
   end
 
   context "when response is invalid" do
     it "fails" do
-      expect { public_key_credential.verify("another challenge") }.to raise_error
+      expect { public_key_credential.verify("another challenge") }.to raise_error(WebAuthn::ChallengeVerificationError)
     end
   end
 end


### PR DESCRIPTION
E.g: 

> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<RuntimeError: invalid type>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/bdewater/src/github.com/bdewater/webauthn-ruby/spec/webauthn/public_key_credential_spec.rb:59:in `block (4 levels) in <top (required)>'.