### PR TITLE
U2F migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ Or install it yourself as:
 
 ## Usage
 
-NOTE: You can find a working example on how to use this gem in a __Rails__ app in [webauthn-rails-demo-app](https://github.com/cedarcode/webauthn-rails-demo-app).
+You can find a working example on how to use this gem in a __Rails__ app in [webauthn-rails-demo-app](https://github.com/cedarcode/webauthn-rails-demo-app).
+
+If you are migrating an existing application from the legacy FIDO U2F JavaScript API to WebAuthn, also refer to
+[`docs/u2f_migration.md`](https://github.com/cedarcode/webauthn-ruby/blob/u2f-migration-doc/docs/u2f_migration.md).
 
 ### Configuration
 

--- a/docs/u2f_migration.md
+++ b/docs/u2f_migration.md
@@ -1,0 +1,96 @@
+# Migrating from U2F to WebAuthn
+
+The Chromium team [recommends](https://groups.google.com/a/chromium.org/forum/#!msg/security-dev/BGWA1d7a6rI/W2avestmBAAJ)
+application developers to switch from the U2F API to the WebAuthn API. This document describes how a Ruby application
+using the [u2f gem by Castle](https://github.com/castle/ruby-u2f) can migrate existing credentials so that their users
+do not experience interruption or need to re-register their security keys.
+
+Note that the migration is one-way: credentials registered using WebAuthn cannot be made compatible with the U2F API.
+It is recommended to successfully migrate authorization flows before migrating registration flows.
+
+## Migrate registered U2F credentials
+
+Assuming you have a registered credential per the u2f gem readme, base64 urlsafe encoded in a database:
+
+```ruby
+# This domain will be used in all code examples. It's a single-facet app but a multi-facet AppID
+# (e.g. https://example.com/app-id.json) will work as well.
+domain = URI("https://login.example.com")
+
+u2f_registration = U2F::U2F.new(domain.to_s).register!(u2f_challenge, u2f_register_response)
+# => #<U2F::Registration:0x00007fd62f43d688
+#  @certificate=
+#   "MIIBCzCBsgIBATAKBggqhkjOPQQDAjASMRAwDgYDVQQDDAdVMkZUZXN0MB4XDTE5MDUzMDE3MjIwM1oXDTIwMDUyOTE3MjIwM1owEjEQMA4GA1UEAwwHVTJGVGVzdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABBMKpejumzlH6NxWIx2Ol+EManS9oX5nguG4RT43rZNkyn/zGjdJEhXksN5zT34rLZgFheBgkDGJCdtTPlhVK10wCgYIKoZIzj0EAwIDSAAwRQIhALYxFcROCeifWpv5+wNZIiaO/bGQg8rFBHCw3aHgehdZAiBJ3xFmQh7+Gjxt6CeAcY/k/VVAYu2vP4sUqXnCQFgJUA==",
+#  @key_handle="mbVMRTgzST5xLumckGztJ9VFW6veObfNIYWSn3sTqIY",
+#  @public_key="BOJQXlFg+ZfZKm48FNq2Ye5vSwOscE1i7YsGRSIjIe3GI0OXrSBDADDn0dQlz2iDzZ7LvCwiHz72U1qhVas3vus=">
+```
+
+The `U2fMigrator` class quacks like `WebAuthn::AuthenticatorAttestationResponse` and can be used similarly as documented
+in the [registration verification phase](https://github.com/cedarcode/webauthn-ruby/blob/master/README.md#verification-phase).
+Of course a `verify` instance method is not implemented, as there is no real interaction with an authenticator.
+
+The migrator can be used to convert credentials in real time during authentication while keeping them stored in the U2F
+format, and in a backfill task to store credentials in the new format, depending on how you are approaching your
+migration.
+
+```ruby
+require "webauthn/u2f_migrator"
+
+migrated_credential = WebAuthn::U2fMigrator.new(
+  app_id: domain,
+  certificate: u2f_registration.certificate,
+  key_handle: u2f_registration.key_handle,
+  public_key: u2f_registration.public_key,
+  counter: u2f_registration.counter
+)
+migrated_credential.credential.id
+# => "\x99\xB5LE83I>q.\xE9\x9C\x90l\xED'\xD5E[\xAB\xDE9\xB7\xCD!\x85\x92\x9F{\x13\xA8\x86"
+migrated_credential.credential.public_key
+# => "\xA5\x03& \x01!X \xE2P^Q`\xF9\x97\xD9*n<\x14\xDA\xB6a\xEEoK\x03\xACpMb\xED\x8B\x06E\"#!\xED\xC6\x01\x02\"X #C\x97\xAD C\x000\xE7\xD1\xD4%\xCFh\x83\xCD\x9E\xCB\xBC,\"\x1F>\xF6SZ\xA1U\xAB7\xBE\xEB"
+migrated_credential.authenticator_data.sign_count
+# => 41
+```
+
+## Authenticate migrated U2F credentials
+
+Following the documentation on the [authentication initiation](https://github.com/cedarcode/webauthn-ruby/blob/master/README.md#authentication),
+you need to specify the [FIDO AppID extension](https://www.w3.org/TR/webauthn/#sctn-appid-extension) for U2F migratedq
+credentials. The WebAuthn standard explains:
+
+> The FIDO APIs use an alternative identifier for Relying Parties called an _AppID_, and any credentials created using
+> those APIs will be scoped to that identifier. Without this extension, they would need to be re-registered in order to
+> be scoped to an RP ID.
+
+For the earlier given example `domain` this means:
+- FIDO AppID: `https://login.example.com`
+- Valid RP IDs: `login.example.com` (default) and `example.com`
+
+```ruby
+credential_request_options = WebAuthn.credential_request_options
+credential_request_options[:extensions] = { appid: domain.to_s }
+```
+
+On the frontend, in the resolved value from `navigator.credentials.get({ "publicKey": credentialRequestOptions })` add
+a call to [getClientExtensionResults()](https://www.w3.org/TR/webauthn/#dom-publickeycredential-getclientextensionresults)
+and send its result to your backend alongside the `id`/`rawId` and `response` values. If the authenticator used the AppID
+extension, the returned value will contain `{ "appid": true }`. In the example below, we use `clientExtensionResults`.
+
+During authentication verification phase, you must pass either the original AppID or the RP ID as the `rp_id` argument:
+
+> If true, the AppID was used and thus, when verifying an assertion, the Relying Party MUST expect the `rpIdHash` to be
+> the hash of the _AppID_, not the RP ID.
+
+```ruby
+assertion_response = WebAuthn::AuthenticatorAssertionResponse.new(
+  credential_id: params[:id],
+  authenticator_data: params[:response][:authenticatorData],
+  client_data_json: params[:response][:clientDataJSON],
+  signature: params[:response][:signature],
+)
+
+assertion_response.verify(
+  expected_challenge,
+  allowed_credentials: [credential],
+  rp_id: params[:clientExtensionResults][:appid] ? domain.to_s : domain.host,
+)
+```

--- a/lib/webauthn/u2f_migrator.rb
+++ b/lib/webauthn/u2f_migrator.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'webauthn/fake_client'
+require 'webauthn/attestation_statement/fido_u2f'
+
+module WebAuthn
+  class U2fMigrator
+    def initialize(app_id:, certificate:, key_handle:, public_key:, counter:)
+      @app_id = app_id
+      @certificate = certificate
+      @key_handle = key_handle
+      @public_key = public_key
+      @counter = counter
+    end
+
+    def authenticator_data
+      @authenticator_data ||= WebAuthn::FakeAuthenticator::AuthenticatorData.new(
+        rp_id_hash: OpenSSL::Digest::SHA256.digest(@app_id.to_s),
+        credential: {
+          id: credential_id,
+          public_key: credential_cose_key
+        },
+        sign_count: @counter,
+        user_present: true,
+        user_verified: false,
+        aaguid: WebAuthn::AttestationStatement::FidoU2f::VALID_ATTESTED_AAGUID,
+      )
+    end
+
+    def credential
+      @credential ||= begin
+        hash = authenticator_data.send(:credential)
+        WebAuthn::AuthenticatorData::AttestedCredentialData::Credential.new(hash[:id], hash[:public_key].serialize)
+      end
+    end
+
+    def attestation_type
+      WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC_OR_ATTCA
+    end
+
+    def attestation_trust_path
+      @attestation_trust_path ||= [OpenSSL::X509::Certificate.new(Base64.strict_decode64(@certificate))]
+    end
+
+    private
+
+    # https://fidoalliance.org/specs/fido-v2.0-rd-20180702/fido-client-to-authenticator-protocol-v2.0-rd-20180702.html#u2f-authenticatorMakeCredential-interoperability
+    # Let credentialId be a credentialIdLength byte array initialized with CTAP1/U2F response key handle bytes.
+    def credential_id
+      Base64.urlsafe_decode64(@key_handle)
+    end
+
+    # Let x9encodedUserPublicKey be the user public key returned in the U2F registration response message [U2FRawMsgs].
+    # Let coseEncodedCredentialPublicKey be the result of converting x9encodedUserPublicKey’s value from ANS X9.62 /
+    # Sec-1 v2 uncompressed curve point representation [SEC1V2] to COSE_Key representation ([RFC8152] Section 7).
+    def credential_cose_key
+      decoded_public_key = Base64.strict_decode64(@public_key)
+      if WebAuthn::AttestationStatement::FidoU2f::PublicKey.uncompressed_point?(decoded_public_key)
+        COSE::Key::EC2.new(
+          alg: COSE::Algorithm.by_name("ES256").id,
+          crv: 1,
+          x: decoded_public_key[1..32],
+          y: decoded_public_key[33..-1]
+        )
+      else
+        raise "expected U2F public key to be in uncompressed point format"
+      end
+    end
+  end
+end

--- a/spec/support/seeds.rb
+++ b/spec/support/seeds.rb
@@ -57,5 +57,21 @@ def seeds
         "client_data_json": "eyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJjaGFsbGVuZ2UiOiJ2MmgxYzJWeWJtRnRaWFEwYVY5T2JUUm9iakZEZUVrd1NHYzNPSGh6VFdsamFHRnNiR1Z1WjJWUXR1YkVEQzRPU3BHSGViSExMTmVyRmY4IiwidHlwZSI6IndlYmF1dGhuLmNyZWF0ZSJ9"
       },
     },
+    u2f_migration: {
+      stored_credential: {
+        certificate: "MIIBNDCB26ADAgECAgp2ubKB51u9YwjcMAoGCCqGSM49BAMCMBUxEzARBgNVBAMTClUyRiBJc3N1ZXIwGhcLMDAwMTAxMDAwMFoXCzAwMDEwMTAwMDBaMBUxEzARBgNVBAMTClUyRiBEZXZpY2UwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQfqziP5Gobu7FmIoFH0WCaD15knMWpIiLgeero1dVBVt2qo62PNI6GktGDUkzCwoj5pENTzTFVDUqAZTHDHTN1oxcwFTATBgsrBgEEAYLlHAIBAQQEAwIFIDAKBggqhkjOPQQDAgNIADBFAiEAwaOmji8WpyFGJwV/YrtyjJ4D56G6YtBGUk5FbSwvP3MCIAtfeOURqhgSn28jbZITIn2StOZ+31PoFt+wXZ3IuQ/e",
+        key_handle: "1a9tIwwYiYNdmfmxVaksOkxKapK2HtDNSsL4MssbCHILhkMzA0xZYk5IHmBljyblTQ_SnsQea-QEMzgTN2L1Mw",
+        public_key: "BBbTnfbd5sY+rCxZDQi87+akvZedjIqR8567GfrsLR0Gnp4zBpD5zhdSq1wKPvhzEoKJvFuYel1cpdTCzpahrBA=",
+      },
+      assertion: {
+        challenge: "v7G2KR2NYPW6AWxfevjMYflTxbWQqLwEoaZkOnm25K8=",
+        id: "1a9tIwwYiYNdmfmxVaksOkxKapK2HtDNSsL4MssbCHILhkMzA0xZYk5IHmBljyblTQ/SnsQea+QEMzgTN2L1Mw==",
+        response: {
+          client_data_json: "eyJjaGFsbGVuZ2UiOiJ2N0cyS1IyTllQVzZBV3hmZXZqTVlmbFR4YldRcUx3RW9hWmtPbm0yNUs4Iiwib3JpZ2luIjoiaHR0cHM6Ly9mNjlkZjRkOS5uZ3Jvay5pbyIsInR5cGUiOiJ3ZWJhdXRobi5nZXQifQ==",
+          signature: "MEYCIQCvDq6m7mzBlfhbu+Y20018/iesDoaRyMOwMjVLUgKdJQIhAMFscVb7oUrIhEU/btWUWMj9xjXN9PSUio6ApytJ4Vd7",
+          authenticator_data: "wqc1M3OySstQSIGfoFIjkPhIJrGaCJiQKPeryg70zSsBAAAAbQ=="
+        }
+      }
+    }
   }
 end

--- a/spec/webauthn/u2f_migrator_spec.rb
+++ b/spec/webauthn/u2f_migrator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/seeds"
+require "byebug"
+
+require "webauthn/u2f_migrator"
+
+RSpec.describe WebAuthn::U2fMigrator do
+  let(:stored_credential) { seeds[:u2f_migration][:stored_credential] }
+  let(:app_id) { URI("https://f69df4d9.ngrok.io") }
+
+  subject do
+    described_class.new(
+      app_id: app_id,
+      certificate: stored_credential[:certificate],
+      key_handle: stored_credential[:key_handle],
+      public_key: stored_credential[:public_key],
+      counter: 41
+    )
+  end
+
+  it "returns the credential ID" do
+    expect(Base64.strict_encode64(subject.credential.id))
+      .to eq("1a9tIwwYiYNdmfmxVaksOkxKapK2HtDNSsL4MssbCHILhkMzA0xZYk5IHmBljyblTQ/SnsQea+QEMzgTN2L1Mw==")
+  end
+
+  it "returns the credential public key in COSE format" do
+    public_key = COSE::Key.deserialize(subject.credential.public_key)
+
+    expect(public_key.alg).to eq(-7)
+    expect(public_key.crv).to eq(1)
+    expect(public_key.x).to eq(Base64.strict_decode64("FtOd9t3mxj6sLFkNCLzv5qS9l52MipHznrsZ+uwtHQY="))
+    expect(public_key.y).to eq(Base64.strict_decode64("np4zBpD5zhdSq1wKPvhzEoKJvFuYel1cpdTCzpahrBA="))
+  end
+
+  it "returns the signature counter" do
+    expect(subject.authenticator_data.sign_count).to eq(41)
+  end
+
+  it "returns the 'Basic or AttCA' attestation type" do
+    expect(subject.attestation_type).to eq("Basic_or_AttCA")
+  end
+
+  it "returns the attestation certificate" do
+    certificate = subject.attestation_trust_path.first
+
+    expect(certificate.subject.to_s).to eq("/CN=U2F Device")
+    expect(certificate.issuer.to_s).to eq("/CN=U2F Issuer")
+  end
+end


### PR DESCRIPTION
Spent an afternoon hacking on this with @jdongelmans and we managed to make something work 😄Still need to figure out the last part on how to make credentials registered with U2F and WebAuthn play nicely with each other, but the rest of it is ready for review.

Closes https://github.com/cedarcode/webauthn-ruby/issues/92

cc @lgarron @sandergroen @brodock requesting your feedback since you have expressed interest on this subject here. If there's any implementation experience you can share, that'd be awesome 🙌