### PR TITLE
FIDO App ID extension support for backwards compatibility with U2F

### DIFF
--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -20,8 +20,20 @@ module WebAuthn
       @signature = signature
     end
 
-    def verify(expected_challenge, expected_origin = nil, allowed_credentials:, user_verification: nil, rp_id: nil)
-      super(expected_challenge, expected_origin, user_verification: user_verification, rp_id: rp_id)
+    def verify(
+      expected_challenge,
+      expected_origin = nil,
+      allowed_credentials:,
+      user_verification: nil,
+      rp_id: nil,
+      fido_app_id: nil
+    )
+      super(
+        expected_challenge,
+        expected_origin,
+        user_verification: user_verification,
+        rp_id: rp_id,
+        fido_app_id: fido_app_id)
 
       verify_item(:credential, allowed_credentials)
       verify_item(:signature, credential_cose_key(allowed_credentials))

--- a/lib/webauthn/client_data.rb
+++ b/lib/webauthn/client_data.rb
@@ -30,6 +30,10 @@ module WebAuthn
       data["tokenBinding"]
     end
 
+    def client_extensions
+      data["clientExtensions"]
+    end
+
     def valid_token_binding_format?
       if token_binding
         token_binding.is_a?(Hash) && VALID_TOKEN_BINDING_STATUSES.include?(token_binding["status"])


### PR DESCRIPTION
Addresses the last issue with https://github.com/cedarcode/webauthn-ruby/pull/211 - tests still todo