### PR TITLE
Add signature counter verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,12 @@ begin
   attestation_response.verify(expected_challenge)
 
   # 1. Register the new user and
-  # 2. Keep Credential ID and Credential Public Key under storage
+  # 2. Keep Credential ID, Credential Public Key and Sign Count under storage
   #    for future authentications
   #    Access by invoking:
   #      `attestation_response.credential.id`
   #      `attestation_response.credential.public_key`
+  #      `attestation_response.authenticator_data.sign_count`
 rescue WebAuthn::VerificationError => e
   # Handle error
 end
@@ -170,6 +171,7 @@ Assuming you have the previously stored Credential Public Key, now in variable `
 #
 # E.g. in https://github.com/cedarcode/webauthn-rails-demo-app we use `Base64.strict_decode64`
 # on the user-agent encoded data before calling `#verify`
+selected_credential_id = "..."
 authenticator_data = "..."
 client_data_json = "..."
 signature = "..."
@@ -185,7 +187,8 @@ assertion_response = WebAuthn::AuthenticatorAssertionResponse.new(
 # previously stored credential for the user that is attempting to sign in.
 allowed_credential = {
   id: credential_id,
-  public_key: credential_public_key
+  public_key: credential_public_key,
+  sign_count: sign_count,
 }
 
 begin
@@ -195,6 +198,9 @@ begin
 rescue WebAuthn::VerificationError => e
   # Handle error
 end
+
+# Find the selected credential in your data storage using `selected_credential_id`
+# Update the stored sign count with the value from `assertion_response.authenticator_data.sign_count`
 ```
 
 ## Attestation Statement Formats

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ client_data_json = "..."
 signature = "..."
 
 assertion_response = WebAuthn::AuthenticatorAssertionResponse.new(
+  credential_id: selected_credential_id,
   authenticator_data: authenticator_data,
   client_data_json: client_data_json,
   signature: signature

--- a/lib/webauthn/fake_authenticator.rb
+++ b/lib/webauthn/fake_authenticator.rb
@@ -35,7 +35,8 @@ module WebAuthn
       client_data_hash:,
       user_present: true,
       user_verified: false,
-      aaguid: AuthenticatorData::AAGUID
+      aaguid: AuthenticatorData::AAGUID,
+      sign_count: 0
     )
       credential_options = credentials[rp_id]
 
@@ -47,6 +48,7 @@ module WebAuthn
           user_present: user_present,
           user_verified: user_verified,
           aaguid: aaguid,
+          sign_count: sign_count,
         ).serialize
 
         signature = credential_key.sign("SHA256", authenticator_data + client_data_hash)

--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -41,7 +41,7 @@ module WebAuthn
       }
     end
 
-    def get(challenge: fake_challenge, rp_id: nil, user_present: true, user_verified: false)
+    def get(challenge: fake_challenge, rp_id: nil, user_present: true, user_verified: false, sign_count: 0)
       rp_id ||= URI.parse(origin).host
 
       client_data_json = data_json_for(:get, challenge)
@@ -51,7 +51,8 @@ module WebAuthn
         rp_id: rp_id,
         client_data_hash: client_data_hash,
         user_present: user_present,
-        user_verified: user_verified
+        user_verified: user_verified,
+        sign_count: sign_count,
       )
 
       {


### PR DESCRIPTION
This implements step 17 of [Verifying an Authentication Assertion](https://www.w3.org/TR/webauthn/#verifying-assertion). While working on the U2F migration I realized it'd be weird to lose the signature count verification by migrating to WebAuthn.

While working on this I realized the way we pass `allowed_credentials` doesn't really work nicely in the case you still need the stored credential for something after. This is being improved in the 2.0 API: https://github.com/cedarcode/webauthn-ruby/pull/194

Also related to https://github.com/cedarcode/webauthn-ruby/issues/200 although the conformance tool was already passing this test, only the Ruby error is `UserVerifiedVerificationError` instead of the expected `SignCountVerificationError` so that still needs looking into.