### PR TITLE
Changed allowed_credentials to just take one public_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ credential_request_options[:challenge]
 
 #### Verification phase
 
-Assuming you have the previously stored Credential Public Key, now in variable `credential_public_key`
+You need to look up the stored credential for a user by matching the `id` attribute from the PublicKeyCredential 
+interface returned by the browser to the stored `credential_id`. The corresponding `public_key` and `sign_count` 
+attributes must be passed as keyword arguments to the `verify` method call.
 
 ```ruby
 # These should be ruby `String`s encoded as binary data, e.g. `Encoding:ASCII-8BIT`.
@@ -212,36 +214,24 @@ Assuming you have the previously stored Credential Public Key, now in variable `
 #
 # E.g. in https://github.com/cedarcode/webauthn-rails-demo-app we use `Base64.strict_decode64`
 # on the user-agent encoded data before calling `#verify`
-selected_credential_id = "..."
 authenticator_data = "..."
 client_data_json = "..."
 signature = "..."
 
 assertion_response = WebAuthn::AuthenticatorAssertionResponse.new(
-  credential_id: selected_credential_id,
   authenticator_data: authenticator_data,
   client_data_json: client_data_json,
   signature: signature
 )
 
-# This hash must have the id and its corresponding public key of the
-# previously stored credential for the user that is attempting to sign in.
-allowed_credential = {
-  id: credential_id,
-  public_key: credential_public_key,
-  sign_count: sign_count,
-}
-
+credential = "..."
 begin
-  assertion_response.verify(expected_challenge, allowed_credentials: [allowed_credential])
-
+  assertion_response.verify(expected_challenge, public_key: credential.public_key, sign_count: credential.sign_count)
+  # Update the stored credential sign count with the value from `assertion_response.authenticator_data.sign_count`
   # Sign in the user
 rescue WebAuthn::VerificationError => e
   # Handle error
 end
-
-# Find the selected credential in your data storage using `selected_credential_id`
-# Update the stored sign count with the value from `assertion_response.authenticator_data.sign_count`
 ```
 
 ## API

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -38,8 +38,6 @@ module WebAuthn
         id: credential["id"],
         raw_id: encoder.decode(credential["rawId"]),
         response: WebAuthn::AuthenticatorAssertionResponse.new(
-          # FIXME: credential_id doesn't belong inside AuthenticatorAssertionResponse
-          credential_id: Base64.urlsafe_decode64(credential["id"]),
           authenticator_data: encoder.decode(credential["response"]["authenticatorData"]),
           client_data_json: encoder.decode(credential["response"]["clientDataJSON"]),
           signature: encoder.decode(credential["response"]["signature"]),


### PR DESCRIPTION
This is a breaking change, hence targeted for 2.0.

The reason to push the responsibility up to the application to find the right public_key for a given credential ID is that applications that want to do signature counter verification and updating (a "SHOULD" in the standard) need to do so anyway. It doesn't make much sense to have both the gem and the app find the right credential independently. This came up in https://github.com/cedarcode/webauthn-ruby/pull/215

The AuthenticatorAssertionResponse object doesn't need to know about the credential ID anymore either.