### PR TITLE
Format AAGUIDs properly

### DIFF
--- a/lib/webauthn/attestation_statement/fido_u2f.rb
+++ b/lib/webauthn/attestation_statement/fido_u2f.rb
@@ -16,7 +16,7 @@ module WebAuthn
         valid_format? &&
           valid_certificate_public_key? &&
           valid_credential_public_key?(authenticator_data.credential.public_key) &&
-          valid_aaguid?(authenticator_data.attested_credential_data.aaguid) &&
+          valid_aaguid?(authenticator_data.attested_credential_data.raw_aaguid) &&
           valid_signature?(authenticator_data, client_data_hash) &&
           [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC_OR_ATTCA, [attestation_certificate]]
       end

--- a/lib/webauthn/attestation_statement/packed.rb
+++ b/lib/webauthn/attestation_statement/packed.rb
@@ -18,7 +18,7 @@ module WebAuthn
           valid_certificate_chain? &&
           valid_ec_public_keys?(authenticator_data.credential) &&
           meet_certificate_requirement? &&
-          matching_aaguid?(authenticator_data.attested_credential_data.aaguid) &&
+          matching_aaguid?(authenticator_data.attested_credential_data.raw_aaguid) &&
           valid_signature?(authenticator_data, client_data_hash) &&
           attestation_type_and_trust_path
       end

--- a/lib/webauthn/attestation_statement/tpm.rb
+++ b/lib/webauthn/attestation_statement/tpm.rb
@@ -25,7 +25,7 @@ module WebAuthn
             valid_attestation_certificate? &&
             pub_area.valid?(authenticator_data.credential.public_key) &&
             cert_info.valid?(statement["pubArea"], OpenSSL::Digest.digest(cose_algorithm.hash, att_to_be_signed)) &&
-            matching_aaguid?(authenticator_data.attested_credential_data.aaguid) &&
+            matching_aaguid?(authenticator_data.attested_credential_data.raw_aaguid) &&
             [attestation_type, attestation_trust_path]
         when ATTESTATION_TYPE_ECDAA
           raise(

--- a/lib/webauthn/authenticator_data/attested_credential_data.rb
+++ b/lib/webauthn/authenticator_data/attested_credential_data.rb
@@ -26,8 +26,12 @@ module WebAuthn
         data.length >= AAGUID_LENGTH + ID_LENGTH_LENGTH && valid_credential_public_key?
       end
 
-      def aaguid
+      def raw_aaguid
         data_at(0, AAGUID_LENGTH)
+      end
+
+      def aaguid
+        raw_aaguid.unpack("H8H4H4H4H12").join("-")
       end
 
       def credential

--- a/spec/webauthn/attestation_statement/packed_spec.rb
+++ b/spec/webauthn/attestation_statement/packed_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Packed attestation" do
       let(:attestation_certificate_version) { 2 }
       let(:attestation_certificate_subject) { "/C=UY/O=ACME/OU=Authenticator Attestation/CN=CN" }
       let(:attestation_certificate_basic_constraints) { "CA:FALSE" }
-      let(:attestation_certificate_aaguid) { authenticator_data.attested_credential_data.aaguid }
+      let(:attestation_certificate_aaguid) { authenticator_data.attested_credential_data.raw_aaguid }
       let(:attestation_certificate_start_time) { Time.now }
       let(:attestation_certificate_end_time) { Time.now + 60 }
 

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -82,7 +82,9 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "returns the AAGUID" do
-      expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to eq("\x00" * 16)
+      expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to(
+        eq("00000000-0000-0000-0000-000000000000")
+      )
     end
   end
 
@@ -124,7 +126,9 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "returns the AAGUID" do
-      expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to eq("\x00" * 16)
+      expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to(
+        eq("00000000-0000-0000-0000-000000000000")
+      )
     end
   end
 
@@ -167,7 +171,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
     it "returns the AAGUID" do
       expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to(
-        eq(["f8a011f38c0a4d15800617111f9edc7d"].pack("H*"))
+        eq("f8a011f3-8c0a-4d15-8006-17111f9edc7d")
       )
     end
   end
@@ -243,7 +247,9 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "returns the AAGUID" do
-      expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to eq("\x00" * 16)
+      expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to(
+        eq("00000000-0000-0000-0000-000000000000")
+      )
     end
   end
 
@@ -284,7 +290,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
     it "returns the AAGUID" do
       expect(attestation_response.authenticator_data.attested_credential_data.aaguid).to(
-        eq(["550e4b54aa47409f9a951ab76c130131"].pack("H*"))
+        eq("550e4b54-aa47-409f-9a95-1ab76c130131")
       )
     end
   end


### PR DESCRIPTION
This makes it easier to look them up in the metadata service