### PR TITLE
Properly verify SafetyNet certificates from input

### DIFF
--- a/lib/webauthn/attestation_statement/android_safetynet.rb
+++ b/lib/webauthn/attestation_statement/android_safetynet.rb
@@ -23,10 +23,7 @@ module WebAuthn
       private
 
       def trusted_attestation_certificate?(trust_store)
-        signing_certificates.each do |certificate|
-          trust_store.add_cert(certificate)
-        end
-        trust_store.verify(attestation_certificate)
+        trust_store.verify(attestation_certificate, signing_certificates)
       end
 
       def valid_response?(authenticator_data, client_data_hash)


### PR DESCRIPTION
[`add_cert`](https://www.openssl.org/docs/man1.1.1/man3/X509_STORE_add_cert.html) is for added trusted root certificates, the second argument to `verify` is for any untrusted intermediate or root certificate input