### PR TITLE
feat: configure timeout in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ WebAuthn.configure do |config|
   # Relying Party name for display purposes
   config.rp_name = "Example Inc."
 
+  # Optionally configure a client timeout hint, in milliseconds.
+  # This hint specifies how long the browser should wait for an
+  # attestation or an assertion response.
+  # This hint may be overridden by the browser.
+  # https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-timeout
+  config.credential_options_timeout = 120000
+
   # You can optionally specify a different Relying Party ID
   # (https://www.w3.org/TR/webauthn/#relying-party-identifier)
   # if it differs from the default one.

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -23,10 +23,12 @@ module WebAuthn
     attr_accessor :rp_id
     attr_accessor :rp_name
     attr_accessor :verify_attestation_statement
+    attr_accessor :credential_options_timeout
 
     def initialize
       @algorithms = DEFAULT_ALGORITHMS.dup
       @verify_attestation_statement = true
+      @credential_options_timeout = 120000
     end
   end
 end

--- a/lib/webauthn/credential_creation_options.rb
+++ b/lib/webauthn/credential_creation_options.rb
@@ -42,6 +42,7 @@ module WebAuthn
       options = {
         challenge: challenge,
         pubKeyCredParams: pub_key_cred_params,
+        timeout: timeout,
         user: { id: user.id, name: user.name, displayName: user.display_name },
         rp: { name: rp.name }
       }

--- a/lib/webauthn/credential_options.rb
+++ b/lib/webauthn/credential_options.rb
@@ -9,5 +9,9 @@ module WebAuthn
     def challenge
       @challenge ||= SecureRandom.random_bytes(CHALLENGE_LENGTH)
     end
+
+    def timeout
+      @timeout = WebAuthn.configuration.credential_options_timeout
+    end
   end
 end

--- a/lib/webauthn/credential_request_options.rb
+++ b/lib/webauthn/credential_request_options.rb
@@ -17,7 +17,11 @@ module WebAuthn
     end
 
     def to_h
-      options = { challenge: challenge, allowCredentials: allow_credentials }
+      options = {
+        challenge: challenge,
+        timeout: timeout,
+        allowCredentials: allow_credentials
+      }
 
       if extensions
         options[:extensions] = extensions

--- a/spec/webauthn/credential_creation_options_spec.rb
+++ b/spec/webauthn/credential_creation_options_spec.rb
@@ -83,4 +83,20 @@ RSpec.describe WebAuthn::CredentialCreationOptions do
     expect(creation_options.user.name).to eq("User")
     expect(creation_options.user.display_name).to eq("User Display")
   end
+
+  context "client timeout" do
+    it "has a default client timeout" do
+      expect(creation_options.timeout).to(eq(120000))
+    end
+
+    context "when client timeout is configured" do
+      before do
+        WebAuthn.configuration.credential_options_timeout = 60000
+      end
+
+      it "updates the client timeout" do
+        expect(creation_options.timeout).to(eq(60000))
+      end
+    end
+  end
 end

--- a/spec/webauthn/credential_request_options_spec.rb
+++ b/spec/webauthn/credential_request_options_spec.rb
@@ -15,4 +15,20 @@ RSpec.describe WebAuthn::CredentialRequestOptions do
   it "has allowCredentials param with an empty array" do
     expect(request_options.allow_credentials).to match_array([])
   end
+
+  context "client timeout" do
+    it "has a default client timeout" do
+      expect(request_options.timeout).to(eq(120000))
+    end
+
+    context "when client timeout is configured" do
+      before do
+        WebAuthn.configuration.credential_options_timeout = 60000
+      end
+
+      it "updates the client timeout" do
+        expect(request_options.timeout).to(eq(60000))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add the ability to configure timeout in config. Defaults to 120s.

Closes #181 