### PR TITLE
feat: make PublicKeyCredential default encoding more compatible with external tools

### DIFF
--- a/lib/webauthn/encoder.rb
+++ b/lib/webauthn/encoder.rb
@@ -6,7 +6,7 @@ module WebAuthn
   class Encoder
     attr_reader :encoding
 
-    def initialize(encoding = :base64)
+    def initialize(encoding = :base64url)
       @encoding = encoding
     end
 

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -11,7 +11,7 @@ module WebAuthn
 
     attr_reader :type, :id, :raw_id, :response
 
-    def self.from_create(credential, encoding: :base64)
+    def self.from_create(credential, encoding: :base64url)
       encoder = WebAuthn::Encoder.new(encoding)
 
       new(
@@ -25,7 +25,7 @@ module WebAuthn
       )
     end
 
-    def self.from_get(credential, encoding: :base64)
+    def self.from_get(credential, encoding: :base64url)
       encoder = WebAuthn::Encoder.new(encoding)
 
       user_handle =

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -58,7 +58,7 @@ post "/attestation/options" do
 end
 
 post "/attestation/result" do
-  public_key_credential = WebAuthn::PublicKeyCredential.from_create(params, encoding: :base64url)
+  public_key_credential = WebAuthn::PublicKeyCredential.from_create(params)
   expected_challenge = Base64.urlsafe_decode64(cookies["challenge"])
   public_key_credential.verify(expected_challenge)
 
@@ -92,7 +92,7 @@ post "/assertion/options" do
 end
 
 post "/assertion/result" do
-  public_key_credential = WebAuthn::PublicKeyCredential.from_get(params, encoding: :base64url)
+  public_key_credential = WebAuthn::PublicKeyCredential.from_get(params)
   expected_challenge = Base64.urlsafe_decode64(cookies["challenge"])
 
   allowed_credentials = Credential.registered_for(cookies["username"]).map do |c|

--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -95,21 +95,18 @@ RSpec.describe "PublicKeyCredential" do
 
   describe ".from_create" do
     it "works" do
-      client = WebAuthn::FakeClient.new(encoding: :base64)
+      client = WebAuthn::FakeClient.new(encoding: :base64url)
       credential = client.create
 
       # TODO: Make FakeClient return camelCase string keys instead of snakecase symbols
       public_key_credential = WebAuthn::PublicKeyCredential.from_create(
-        {
-          "id" => credential[:id],
-          "type" => credential[:type],
-          "rawId" => credential[:raw_id],
-          "response" => {
-            "attestationObject" => credential[:response][:attestation_object],
-            "clientDataJSON" => credential[:response][:client_data_json],
-          }
-        },
-        encoding: :base64
+        "id" => credential[:id],
+        "type" => credential[:type],
+        "rawId" => credential[:raw_id],
+        "response" => {
+          "attestationObject" => credential[:response][:attestation_object],
+          "clientDataJSON" => credential[:response][:client_data_json],
+        }
       )
 
       expect(public_key_credential).to be_a(WebAuthn::PublicKeyCredential)
@@ -123,24 +120,21 @@ RSpec.describe "PublicKeyCredential" do
 
   describe ".from_get" do
     it "works" do
-      client = WebAuthn::FakeClient.new(encoding: :base64)
+      client = WebAuthn::FakeClient.new(encoding: :base64url)
       client.create
       credential = client.get
 
       # TODO: Make FakeClient return camelCase string keys instead of snakecase symbols
       public_key_credential = WebAuthn::PublicKeyCredential.from_get(
-        {
-          "id" => credential[:id],
-          "type" => credential[:type],
-          "rawId" => credential[:raw_id],
-          "response" => {
-            "authenticatorData" => credential[:response][:authenticator_data],
-            "clientDataJSON" => credential[:response][:client_data_json],
-            "signature" => credential[:response][:signature],
-            "userHandle" => credential[:response][:user_handle]
-          }
-        },
-        encoding: :base64
+        "id" => credential[:id],
+        "type" => credential[:type],
+        "rawId" => credential[:raw_id],
+        "response" => {
+          "authenticatorData" => credential[:response][:authenticator_data],
+          "clientDataJSON" => credential[:response][:client_data_json],
+          "signature" => credential[:response][:signature],
+          "userHandle" => credential[:response][:user_handle]
+        }
       )
 
       expect(public_key_credential).to be_a(WebAuthn::PublicKeyCredential)


### PR DESCRIPTION
* FIDO2 conformance tools
* @github/webauthn-json

addresses https://github.com/cedarcode/webauthn-ruby/pull/224#discussion_r313445260