### PR TITLE
Make sign_count argument mandatory for verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ begin
   assertion_response.verify(expected_challenge, public_key: credential.public_key, sign_count: credential.sign_count)
   # Update the stored credential sign count with the value from `assertion_response.authenticator_data.sign_count`
   # Sign in the user
+rescue WebAuthn::SignCountVerificationError => e
+  # Cryptographic verification of the authenticator data succeeded, but the signature counter was less then or equal
+  # to the stored value. This can have several reasons and depending on your risk tolerance you can choose to fail or
+  # pass authentication. For more information see https://www.w3.org/TR/webauthn/#sign-counter
 rescue WebAuthn::VerificationError => e
   # Handle error
 end

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -22,7 +22,7 @@ module WebAuthn
       @user_handle = user_handle
     end
 
-    def verify(expected_challenge, expected_origin = nil, public_key:, sign_count: 0, user_verification: nil,
+    def verify(expected_challenge, expected_origin = nil, public_key:, sign_count:, user_verification: nil,
                rp_id: nil)
       super(expected_challenge, expected_origin, user_verification: user_verification, rp_id: rp_id)
       verify_item(:signature, credential_cose_key(public_key))
@@ -46,8 +46,9 @@ module WebAuthn
     end
 
     def valid_sign_count?(stored_sign_count)
-      if authenticator_data.sign_count.nonzero? || stored_sign_count.nonzero?
-        authenticator_data.sign_count > stored_sign_count
+      normalized_sign_count = stored_sign_count || 0
+      if authenticator_data.sign_count.nonzero? || normalized_sign_count.nonzero?
+        authenticator_data.sign_count > normalized_sign_count
       else
         true
       end

--- a/spec/webauthn/authenticator_assertion_response_spec.rb
+++ b/spec/webauthn/authenticator_assertion_response_spec.rb
@@ -32,11 +32,15 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
 
   context "when everything's in place" do
     it "verifies" do
-      expect(assertion_response.verify(original_challenge, public_key: credential_public_key)).to be_truthy
+      expect(
+        assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
+      ).to be_truthy
     end
 
     it "is valid" do
-      expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_truthy
+      expect(
+        assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+      ).to be_truthy
     end
   end
 
@@ -57,7 +61,7 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
         .new(credential_public_key)
         .to_uncompressed_point
 
-      expect(assertion_response.verify(original_challenge, public_key: old_format_key)).to be_truthy
+      expect(assertion_response.verify(original_challenge, public_key: old_format_key, sign_count: 0)).to be_truthy
     end
   end
 
@@ -68,12 +72,12 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
     end
 
     it "is invalid" do
-      expect(assertion_response.valid?(original_challenge, public_key: different_public_key)).to be_falsy
+      expect(assertion_response.valid?(original_challenge, public_key: different_public_key, sign_count: 0)).to be_falsy
     end
 
     it "doesn't verify" do
       expect {
-        assertion_response.verify(original_challenge, public_key: different_public_key)
+        assertion_response.verify(original_challenge, public_key: different_public_key, sign_count: 0)
       }.to raise_exception(WebAuthn::SignatureVerificationError)
     end
   end
@@ -86,12 +90,14 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
 
       it "doesn't verify" do
         expect {
-          assertion_response.verify(original_challenge, public_key: credential_public_key)
+          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
         }.to raise_exception(WebAuthn::TypeVerificationError)
       end
 
       it "is invalid" do
-        expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_falsy
+        expect(
+          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+        ).to be_falsy
       end
     end
   end
@@ -102,12 +108,14 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
     context "if user flags are off" do
       it "doesn't verify" do
         expect {
-          assertion_response.verify(original_challenge, public_key: credential_public_key)
+          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
         }.to raise_exception(WebAuthn::UserPresenceVerificationError)
       end
 
       it "is invalid" do
-        expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_falsy
+        expect(
+          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+        ).to be_falsy
       end
     end
   end
@@ -121,6 +129,7 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
           assertion_response.verify(
             original_challenge,
             public_key: credential_public_key,
+            sign_count: 0,
             user_verification: true
           )
         }.to raise_exception(WebAuthn::UserVerifiedVerificationError)
@@ -132,12 +141,12 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
     context "if challenge doesn't match" do
       it "doesn't verify" do
         expect {
-          assertion_response.verify(fake_challenge, public_key: credential_public_key)
+          assertion_response.verify(fake_challenge, public_key: credential_public_key, sign_count: 0)
         }.to raise_exception(WebAuthn::ChallengeVerificationError)
       end
 
       it "is invalid" do
-        expect(assertion_response.valid?(fake_challenge, public_key: credential_public_key)).to be_falsy
+        expect(assertion_response.valid?(fake_challenge, public_key: credential_public_key, sign_count: 0)).to be_falsy
       end
     end
   end
@@ -148,12 +157,14 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
 
       it "doesn't verify" do
         expect {
-          assertion_response.verify(original_challenge, public_key: credential_public_key)
+          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
         }.to raise_exception(WebAuthn::OriginVerificationError)
       end
 
       it "is invalid" do
-        expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_falsy
+        expect(
+          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+        ).to be_falsy
       end
     end
   end
@@ -165,11 +176,15 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
       let(:token_binding) { { status: "supported" } }
 
       it "verifies" do
-        expect(assertion_response.verify(original_challenge, public_key: credential_public_key)).to be_truthy
+        expect(
+          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
+        ).to be_truthy
       end
 
       it "is valid" do
-        expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_truthy
+        expect(
+          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+        ).to be_truthy
       end
     end
 
@@ -178,12 +193,14 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
 
       it "doesn't verify" do
         expect {
-          assertion_response.verify(original_challenge, public_key: credential_public_key)
+          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
         }.to raise_exception(WebAuthn::TokenBindingVerificationError)
       end
 
       it "isn't valid" do
-        expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_falsy
+        expect(
+          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+        ).to be_falsy
       end
     end
   end
@@ -196,12 +213,14 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
     context "if rp_id_hash doesn't match" do
       it "doesn't verify" do
         expect {
-          assertion_response.verify(original_challenge, public_key: credential_public_key)
+          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
         }.to raise_exception(WebAuthn::RpIdVerificationError)
       end
 
       it "is invalid" do
-        expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_falsy
+        expect(
+          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+        ).to be_falsy
       end
     end
 
@@ -211,6 +230,7 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
           assertion_response.verify(
             original_challenge,
             public_key: credential_public_key,
+            sign_count: 0,
             rp_id: URI.parse(origin).host
           )
         ).to be_truthy
@@ -221,6 +241,7 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
           assertion_response.valid?(
             original_challenge,
             public_key: credential_public_key,
+            sign_count: 0,
             rp_id: URI.parse(origin).host
           )
         ).to be_truthy
@@ -269,6 +290,16 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
           }.to raise_exception(WebAuthn::SignCountVerificationError)
         end
       end
+
+      context "when the RP opts out of verifying the signature counter" do
+        let(:assertion) { client.get(challenge: original_challenge, sign_count: false) }
+
+        it "verifies" do
+          expect {
+            assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 5)
+          }.to raise_exception(WebAuthn::SignCountVerificationError)
+        end
+      end
     end
   end
 
@@ -299,13 +330,13 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
     context "when correct FIDO AppID is given as rp_id" do
       it "verifies" do
         expect(
-          assertion_response.verify(original_challenge, public_key: credential_public_key, rp_id: app_id)
+          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0, rp_id: app_id)
         ).to be_truthy
       end
 
       it "is valid" do
         expect(
-          assertion_response.valid?(original_challenge, public_key: credential_public_key, rp_id: app_id)
+          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0, rp_id: app_id)
         ).to be_truthy
       end
     end
@@ -316,12 +347,14 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
 
     it "doesn't verify" do
       expect {
-        assertion_response.verify(original_challenge, public_key: credential_public_key)
+        assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
       }.to raise_exception(WebAuthn::AuthenticatorDataVerificationError)
     end
 
     it "is invalid" do
-      expect(assertion_response.valid?(original_challenge, public_key: credential_public_key)).to be_falsy
+      expect(
+        assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+      ).to be_falsy
     end
   end
 end


### PR DESCRIPTION
Helps in detecting cloned or malfunctioning authenticators: https://www.w3.org/TR/webauthn-2/#sctn-sign-counter

Applications can keep passing `0` if they wish not to do verify the counter as that'll always make the following return `true`:
https://github.com/cedarcode/webauthn-ruby/blob/95b403a4967bbbdf2606593061c2307aa4d27105/lib/webauthn/authenticator_assertion_response.rb#L48-L54