### PR TITLE
Add new method to generate user ids according to spec recommendation

### DIFF
--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -3,3 +3,10 @@
 require "webauthn/configuration"
 require "webauthn/public_key_credential"
 require "webauthn/version"
+
+module WebAuthn
+  def self.generate_user_id(encoding: :base64url)
+    encoder = WebAuthn::Encoder.new(encoding)
+    encoder.encode(SecureRandom.random_bytes(64))
+  end
+end

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -84,6 +84,12 @@ module WebAuthn
     end
 
     def user_handle
+      if raw_user_handle
+        encoder.encode(raw_user_handle)
+      end
+    end
+
+    def raw_user_handle
       if response.is_a?(WebAuthn::AuthenticatorAssertionResponse)
         response.user_handle
       end

--- a/spec/webauthn/public_key_credential/creation_options_spec.rb
+++ b/spec/webauthn/public_key_credential/creation_options_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 require "webauthn/public_key_credential/creation_options"
 
 RSpec.describe WebAuthn::PublicKeyCredential::CreationOptions do
+  let(:user_id) { WebAuthn.generate_user_id }
   let(:creation_options) do
     WebAuthn::PublicKeyCredential::CreationOptions.new(
-      user: { id: "1", name: "User", display_name: "User Display" }
+      user: { id: user_id, name: "User", display_name: "User Display" }
     )
   end
 
@@ -83,7 +84,7 @@ RSpec.describe WebAuthn::PublicKeyCredential::CreationOptions do
   end
 
   it "has user info" do
-    expect(creation_options.user.id).to eq("1")
+    expect(creation_options.user.id).to eq(user_id)
     expect(creation_options.user.name).to eq("User")
     expect(creation_options.user.display_name).to eq("User Display")
   end

--- a/spec/webauthn_spec.rb
+++ b/spec/webauthn_spec.rb
@@ -72,4 +72,48 @@ RSpec.describe WebAuthn do
       expect(credential_request_options[:allowCredentials]).to match_array([])
     end
   end
+
+  describe "#generate_user_id" do
+    let(:user_id) { WebAuthn.generate_user_id(encoding: encoding) }
+    let(:encoder) { WebAuthn::Encoder.new(encoding) }
+
+    context "when encoding is base64url" do
+      let(:encoding) { :base64url }
+
+      it "is encoded" do
+        expect(user_id.class).to eq(String)
+        expect(user_id.encoding).not_to eq(Encoding::BINARY)
+      end
+
+      it "is 64 bytes long" do
+        expect(encoder.decode(user_id).length).to eq(64)
+      end
+    end
+
+    context "when encoding is base64" do
+      let(:encoding) { :base64 }
+
+      it "is encoded" do
+        expect(user_id.class).to eq(String)
+        expect(user_id.encoding).not_to eq(Encoding::BINARY)
+      end
+
+      it "is 64 bytes long" do
+        expect(encoder.decode(user_id).length).to eq(64)
+      end
+    end
+
+    context "when not encoding" do
+      let(:encoding) { false }
+
+      it "is not encoded" do
+        expect(user_id.class).to eq(String)
+        expect(user_id.encoding).to eq(Encoding::BINARY)
+      end
+
+      it "is 64 bytes long" do
+        expect(user_id.length).to eq(64)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add new `WebAuthn.generate_user_id` method to generate user ids according to spec recommendation.
Closes #258 