### PR TITLE
Use binary encoding alias

### DIFF
--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       credential = attestation_response.credential
 
       expect(credential.id.class).to eq(String)
-      expect(credential.id.encoding).to eq(Encoding::ASCII_8BIT)
+      expect(credential.id.encoding).to eq(Encoding::BINARY)
       expect(credential.public_key.class).to eq(String)
-      expect(credential.public_key.encoding).to be(Encoding::ASCII_8BIT)
+      expect(credential.public_key.encoding).to be(Encoding::BINARY)
     end
   end
 

--- a/spec/webauthn/public_key_credential/creation_options_spec.rb
+++ b/spec/webauthn/public_key_credential/creation_options_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WebAuthn::PublicKeyCredential::CreationOptions do
 
   it "has a challenge" do
     expect(creation_options.challenge.class).to eq(String)
-    expect(creation_options.challenge.encoding).to eq(Encoding::ASCII_8BIT)
+    expect(creation_options.challenge.encoding).to eq(Encoding::BINARY)
     expect(creation_options.challenge.length).to eq(32)
   end
 

--- a/spec/webauthn/public_key_credential/request_options_spec.rb
+++ b/spec/webauthn/public_key_credential/request_options_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WebAuthn::PublicKeyCredential::RequestOptions do
 
   it "has a challenge" do
     expect(request_options.challenge.class).to eq(String)
-    expect(request_options.challenge.encoding).to eq(Encoding::ASCII_8BIT)
+    expect(request_options.challenge.encoding).to eq(Encoding::BINARY)
     expect(request_options.challenge.length).to eq(32)
   end
 


### PR DESCRIPTION
Replace `Encoding::ASCII_8BIT` with `Encoding::BINARY` to make code consistent and more intuitive