### PR TITLE
Set default encoding for FakeClient

### DIFF
--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -16,7 +16,7 @@ module WebAuthn
       origin = fake_origin,
       token_binding: nil,
       authenticator: WebAuthn::FakeAuthenticator.new,
-      encoding: nil
+      encoding: WebAuthn.configuration.encoding
     )
       @origin = origin
       @token_binding = token_binding

--- a/spec/webauthn/authenticator_assertion_response_spec.rb
+++ b/spec/webauthn/authenticator_assertion_response_spec.rb
@@ -7,7 +7,7 @@ require "webauthn/authenticator_assertion_response"
 require "webauthn/u2f_migrator"
 
 RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
-  let(:client) { WebAuthn::FakeClient.new(actual_origin) }
+  let(:client) { WebAuthn::FakeClient.new(actual_origin, encoding: false) }
 
   let!(:credential) { create_credential(client: client) }
   let(:credential_public_key) { credential[1] }
@@ -170,7 +170,7 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
   end
 
   describe "tokenBinding validation" do
-    let(:client) { WebAuthn::FakeClient.new(actual_origin, token_binding: token_binding) }
+    let(:client) { WebAuthn::FakeClient.new(actual_origin, token_binding: token_binding, encoding: false) }
 
     context "it has stuff" do
       let(:token_binding) { { status: "supported" } }

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   let(:original_challenge) { fake_challenge }
   let(:origin) { fake_origin }
 
-  let(:client) { WebAuthn::FakeClient.new(origin) }
+  let(:client) { WebAuthn::FakeClient.new(origin, encoding: false) }
   let(:attestation_response) do
     response = public_key_credential["response"]
 
@@ -313,7 +313,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     let(:original_challenge) { fake_challenge }
 
     let(:attestation_response) do
-      client = WebAuthn::FakeClient.new(actual_origin)
+      client = WebAuthn::FakeClient.new(actual_origin, encoding: false)
       response = client.create(challenge: original_challenge)["response"]
 
       WebAuthn::AuthenticatorAttestationResponse.new(
@@ -353,7 +353,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     let(:original_challenge) { fake_challenge }
 
     let(:attestation_response) do
-      client = WebAuthn::FakeClient.new(origin)
+      client = WebAuthn::FakeClient.new(origin, encoding: false)
       response = client.create(challenge: original_challenge, rp_id: rp_id)["response"]
 
       WebAuthn::AuthenticatorAttestationResponse.new(
@@ -406,7 +406,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   end
 
   describe "tokenBinding validation" do
-    let(:client) { WebAuthn::FakeClient.new(origin, token_binding: token_binding) }
+    let(:client) { WebAuthn::FakeClient.new(origin, token_binding: token_binding, encoding: false) }
 
     context "it has stuff" do
       let(:token_binding) { { status: "supported" } }

--- a/spec/webauthn/credential_spec.rb
+++ b/spec/webauthn/credential_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Credential" do
       WebAuthn::Credential.create_options(user: { id: "1", name: "User" }).challenge
     end
 
-    let(:client) { WebAuthn::FakeClient.new(origin, encoding: encoding) }
+    let(:client) { WebAuthn::FakeClient.new(origin) }
 
     before do
       WebAuthn.configuration.encoding = encoding
@@ -77,7 +77,7 @@ RSpec.describe "Credential" do
       WebAuthn::Credential.get_options.challenge
     end
 
-    let(:client) { WebAuthn::FakeClient.new(origin, encoding: encoding) }
+    let(:client) { WebAuthn::FakeClient.new(origin) }
 
     let(:credential_from_create) do
       WebAuthn::Credential.from_create(created_credential)

--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "PublicKeyCredential" do
       )
     end
 
-    let(:client) { WebAuthn::FakeClient.new(origin) }
+    let(:client) { WebAuthn::FakeClient.new(origin, encoding: false) }
     let(:challenge) { Base64.urlsafe_encode64(raw_challenge) }
     let(:raw_challenge) { fake_challenge }
     let(:origin) { fake_origin }


### PR DESCRIPTION
Use `WebAuthn.configuration.encoding` (which defaults in `:base64url`) as default encoding