### PR TITLE
feat: add ability to optionally enable 'silent authentication'

### DIFF
--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -33,7 +33,10 @@ module WebAuthn
       verify_item(:origin, expected_origin)
       verify_item(:authenticator_data)
       verify_item(:rp_id, rp_id || rp_id_from_origin(expected_origin))
-      verify_item(:user_presence)
+
+      if !WebAuthn.configuration.silent_authentication
+        verify_item(:user_presence)
+      end
 
       if user_verification
         verify_item(:user_verified)

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -26,12 +26,14 @@ module WebAuthn
     attr_accessor :rp_name
     attr_accessor :verify_attestation_statement
     attr_accessor :credential_options_timeout
+    attr_accessor :silent_authentication
 
     def initialize
       @algorithms = DEFAULT_ALGORITHMS.dup
       @encoding = WebAuthn::Encoder::STANDARD_ENCODING
       @verify_attestation_statement = true
       @credential_options_timeout = 120000
+      @silent_authentication = false
     end
 
     # This is the user-data encoder.

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -31,6 +31,7 @@ WebAuthn.configure do |config|
   config.origin = "http://#{host}:#{settings.port}"
   config.rp_name = RP_NAME
   config.algorithms.concat(%w(ES384 ES512 PS384 PS512 RS384 RS512 RS1))
+  config.silent_authentication = true
 end
 
 post "/attestation/options" do


### PR DESCRIPTION
Driven by need to pass FIDO2 conformance tools (v1.2.0) tests:
 - GetAssertion Resp-3 P-4
 - GetAssertion Resp-3 P-7

Closes #199 