### PR TITLE
Pass remaining android-safetynet attestation conformance tests

### DIFF
--- a/lib/android_safetynet/attestation_response.rb
+++ b/lib/android_safetynet/attestation_response.rb
@@ -46,7 +46,7 @@ module AndroidSafetynet
     end
 
     def timestamp
-      Time.at(0, payload["timestampMs"], :millisecond)
+      Time.at((payload["timestampMs"] / 1000.0).round)
     end
 
     private

--- a/lib/android_safetynet/attestation_response.rb
+++ b/lib/android_safetynet/attestation_response.rb
@@ -45,6 +45,10 @@ module AndroidSafetynet
       end
     end
 
+    def timestamp
+      Time.at(0, payload["timestampMs"], :millisecond)
+    end
+
     private
 
     def valid_nonce?(nonce)

--- a/lib/webauthn/attestation_statement/android_safetynet.rb
+++ b/lib/webauthn/attestation_statement/android_safetynet.rb
@@ -28,6 +28,8 @@ module WebAuthn
 
       # FIXME: This should be a responsibility of AndroidSafetynet::AttestationResponse#verify
       def trusted_attestation_certificate?(trust_store)
+        return true if trust_store.nil?
+
         trust_store.verify(attestation_certificate, signing_certificates)
       end
 

--- a/lib/webauthn/attestation_statement/android_safetynet.rb
+++ b/lib/webauthn/attestation_statement/android_safetynet.rb
@@ -17,6 +17,7 @@ module WebAuthn
           valid_response?(authenticator_data, client_data_hash) &&
           valid_version? &&
           cts_profile_match? &&
+          valid_timestamp? &&
           [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC, attestation_certificate]
       end
 
@@ -50,6 +51,11 @@ module WebAuthn
 
       def cts_profile_match?
         attestation_response.cts_profile_match?
+      end
+
+      def valid_timestamp?
+        now = Time.now
+        attestation_response.timestamp.between?(now - 60, now)
       end
 
       def signing_certificates

--- a/lib/webauthn/attestation_statement/android_safetynet.rb
+++ b/lib/webauthn/attestation_statement/android_safetynet.rb
@@ -17,7 +17,6 @@ module WebAuthn
           valid_response?(authenticator_data, client_data_hash) &&
           valid_version? &&
           cts_profile_match? &&
-          valid_timestamp? &&
           [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC, attestation_certificate]
       end
 
@@ -51,11 +50,6 @@ module WebAuthn
 
       def cts_profile_match?
         attestation_response.cts_profile_match?
-      end
-
-      def valid_timestamp?
-        now = Time.now
-        attestation_response.timestamp.between?(now - 60, now)
       end
 
       def signing_certificates

--- a/spec/android_safetynet/attestation_response_spec.rb
+++ b/spec/android_safetynet/attestation_response_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "AttestationResponse" do
       )
     end
 
-    let(:payload) { { nonce: nonce } }
+    let(:payload) { { nonce: nonce, timestampMs: timestamp * 1000 } }
     let(:attestation_key) { OpenSSL::PKey::EC.new("prime256v1").generate_key }
 
     let(:leaf_certificate) do
@@ -37,6 +37,7 @@ RSpec.describe "AttestationResponse" do
 
     let(:leaf_certificate_subject_common_name) { "attest.android.com" }
     let(:nonce) { rand(16).to_s }
+    let(:timestamp) { Time.now.to_i }
 
     it "returns true if everything's in place" do
       expect(attestation_response.verify(nonce)).to be_truthy

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -11,6 +11,7 @@ use Rack::PostBodyContentTypeParser
 set show_exceptions: false
 
 # TODO: remove once safetynet attestation P-1 test certificate problem is fixed
+# https://github.com/fido-alliance/conformance-tools-issues/issues/518
 require 'webauthn/attestation_statement/android_safetynet'
 module WebAuthn
   module AttestationStatement

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -10,7 +10,7 @@ require "byebug"
 use Rack::PostBodyContentTypeParser
 set show_exceptions: false
 
-# HACK: remove once safetynet attestation P-1 test certificate problem is fixed
+# TODO: remove once safetynet attestation P-1 test certificate problem is fixed
 require 'webauthn/attestation_statement/android_safetynet'
 module WebAuthn
   module AttestationStatement

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -10,6 +10,18 @@ require "byebug"
 use Rack::PostBodyContentTypeParser
 set show_exceptions: false
 
+# HACK: remove once safetynet attestation P-1 test certificate problem is fixed
+require 'webauthn/attestation_statement/android_safetynet'
+module WebAuthn
+  module AttestationStatement
+    class AndroidSafetynet < Base
+      def self.default_trust_store
+        nil
+      end
+    end
+  end
+end
+
 RP_NAME = "webauthn-ruby #{WebAuthn::VERSION} conformance test server"
 
 Credential = Struct.new(:id, :public_key, :sign_count) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ end
 # the DONT_FAKE_MONOTONIC=1 and FAKETIME_NO_CACHE=1 environment variables to work as expected for the test suite.
 def fake_time(time)
   old_time = ENV["FAKETIME"]
-  new_time = time.strftime("%Y-%m-%d %H:%M:%S")
+  new_time = time.localtime.strftime("%Y-%m-%d %H:%M:%S")
 
   begin
     ENV["FAKETIME"] = new_time

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -5,7 +5,6 @@ require "spec_helper"
 require "base64"
 require "jwt"
 require "openssl"
-require "timecop"
 require "webauthn/attestation_statement/android_safetynet"
 
 RSpec.describe "android-safetynet attestation" do
@@ -95,26 +94,6 @@ RSpec.describe "android-safetynet attestation" do
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
-      end
-    end
-
-    context "when timestampMs is set to future" do
-      let(:timestamp) { Time.now.to_i + 60 }
-
-      it "returns false" do
-        Timecop.freeze do
-          expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
-        end
-      end
-    end
-
-    context "when timestampMs is older than one minute" do
-      let(:timestamp) { Time.now.to_i - 61 }
-
-      it "returns false" do
-        Timecop.freeze do
-          expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
-        end
       end
     end
   end

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "android-safetynet attestation" do
       let(:nonce) { Base64.strict_encode64(OpenSSL::Digest::SHA256.digest("something else")) }
 
       it "returns false" do
-        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+        expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe "android-safetynet attestation" do
       let(:cts_profile_match) { false }
 
       it "returns false" do
-        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+        expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe "android-safetynet attestation" do
       let(:timestamp) { Time.now + 60 }
 
       it "returns false" do
-        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+        expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
       end
     end
 
@@ -109,7 +109,7 @@ RSpec.describe "android-safetynet attestation" do
       let(:timestamp) { Time.now - 60 }
 
       it "returns false" do
-        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+        expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
       end
     end
   end

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 require "base64"
 require "jwt"
 require "openssl"
+require "timecop"
 require "webauthn/attestation_statement/android_safetynet"
 
 RSpec.describe "android-safetynet attestation" do
@@ -101,15 +102,19 @@ RSpec.describe "android-safetynet attestation" do
       let(:timestamp) { Time.now.to_i + 60 }
 
       it "returns false" do
-        expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
+        Timecop.freeze(Time.now) do
+          expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
+        end
       end
     end
 
-    context "when timestampMs is older than a minute old" do
-      let(:timestamp) { Time.now.to_i - 60 }
+    context "when timestampMs is older than one minute" do
+      let(:timestamp) { Time.now.to_i - 61 }
 
       it "returns false" do
-        expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
+        Timecop.freeze(Time.now) do
+          expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
+        end
       end
     end
   end

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "android-safetynet attestation" do
       let(:timestamp) { Time.now.to_i + 60 }
 
       it "returns false" do
-        Timecop.freeze(Time.now) do
+        Timecop.freeze do
           expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
         end
       end
@@ -112,7 +112,7 @@ RSpec.describe "android-safetynet attestation" do
       let(:timestamp) { Time.now.to_i - 61 }
 
       it "returns false" do
-        Timecop.freeze(Time.now) do
+        Timecop.freeze do
           expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
         end
       end

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "android-safetynet attestation" do
     end
 
     context "when timestampMs is set to future" do
-      let(:timestamp) { Time.now.to_i + 60  }
+      let(:timestamp) { Time.now.to_i + 60 }
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe "android-safetynet attestation" do
       )
     end
 
-    let(:payload) { { "nonce" => nonce, "ctsProfileMatch" => cts_profile_match } }
+    let(:payload) { { "nonce" => nonce, "ctsProfileMatch" => cts_profile_match, "timestampMs" => timestamp } }
+    let(:timestamp) { Time.now.to_i * 1000 }
     let(:cts_profile_match) { true }
     let(:nonce) { Base64.strict_encode64(OpenSSL::Digest::SHA256.digest(authenticator_data_bytes + client_data_hash)) }
     let(:attestation_key) { OpenSSL::PKey::RSA.new(2048) }
@@ -90,6 +91,22 @@ RSpec.describe "android-safetynet attestation" do
 
     context "when ctsProfileMatch is not true" do
       let(:cts_profile_match) { false }
+
+      it "returns false" do
+        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+      end
+    end
+
+    context "when timestampMs is set to future" do
+      let(:timestamp) { Time.now + 60 }
+
+      it "returns false" do
+        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+      end
+    end
+
+    context "when timestampMs is older than a minute old" do
+      let(:timestamp) { Time.now - 60 }
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "android-safetynet attestation" do
     end
 
     context "when timestampMs is set to future" do
-      let(:timestamp) { Time.now + 60 }
+      let(:timestamp) { (Time.now.to_i + 60) * 1000 }
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
@@ -106,7 +106,7 @@ RSpec.describe "android-safetynet attestation" do
     end
 
     context "when timestampMs is older than a minute old" do
-      let(:timestamp) { Time.now - 60 }
+      let(:timestamp) { (Time.now.to_i - 60) * 1000 }
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "android-safetynet attestation" do
       )
     end
 
-    let(:payload) { { "nonce" => nonce, "ctsProfileMatch" => cts_profile_match, "timestampMs" => timestamp } }
-    let(:timestamp) { Time.now.to_i * 1000 }
+    let(:payload) { { "nonce" => nonce, "ctsProfileMatch" => cts_profile_match, "timestampMs" => timestamp * 1000 } }
+    let(:timestamp) { Time.now.to_i }
     let(:cts_profile_match) { true }
     let(:nonce) { Base64.strict_encode64(OpenSSL::Digest::SHA256.digest(authenticator_data_bytes + client_data_hash)) }
     let(:attestation_key) { OpenSSL::PKey::RSA.new(2048) }
@@ -98,7 +98,7 @@ RSpec.describe "android-safetynet attestation" do
     end
 
     context "when timestampMs is set to future" do
-      let(:timestamp) { (Time.now.to_i + 60) * 1000 }
+      let(:timestamp) { Time.now.to_i + 60  }
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy
@@ -106,7 +106,7 @@ RSpec.describe "android-safetynet attestation" do
     end
 
     context "when timestampMs is older than a minute old" do
-      let(:timestamp) { (Time.now.to_i - 60) * 1000 }
+      let(:timestamp) { Time.now.to_i - 60 }
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash, trust_store: trust_store)).to be_falsy

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   end
 
   context "when android-safetynet attestation" do
-    around(:each) { |example| fake_time(Time.new(2019, 8, 7), &example) }
+    around(:each) { |example| fake_time(Time.new(2019, 7, 7, 13, 16), &example) }
 
     let(:origin) { "https://7f41ac45.ngrok.io" }
 

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   end
 
   context "when android-safetynet attestation" do
-    around(:each) { |example| fake_time(Time.new(2019, 7, 7, 13, 16), &example) }
+    around(:each) { |example| fake_time(Time.utc(2019, 7, 7, 16, 16), &example) }
 
     let(:origin) { "https://7f41ac45.ngrok.io" }
 

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rubocop", "0.75.0"
-  spec.add_development_dependency "timecop", "~> 0.8.1"
+  spec.add_development_dependency "timecop", "~> 0.9.1"
 end

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rubocop", "0.75.0"
+  spec.add_development_dependency "timecop", "~> 0.8.1"
 end


### PR DESCRIPTION
Pass MakeCredential Resp-B P-1 (closes #172) conformance test by avoiding the certificate chain verification on the conformance server.
Also closes #240 by correctly validating the timestamp on the attestation.