### PR TITLE
Encapsulate WebAuthn::PublicKey behaviour

### DIFF
--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -56,7 +56,7 @@ module WebAuthn
 
     def valid_signature?(webauthn_public_key)
       WebAuthn::SignatureVerifier
-        .new(webauthn_public_key.cose_key.alg, webauthn_public_key.pkey)
+        .new(webauthn_public_key.alg, webauthn_public_key.pkey)
         .verify(signature, authenticator_data_bytes + client_data.hash)
     end
 

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "cose/algorithm"
-require "cose/key"
-require "webauthn/attestation_statement/fido_u2f/public_key"
 require "webauthn/authenticator_data"
 require "webauthn/authenticator_response"
 require "webauthn/encoder"
 require "webauthn/signature_verifier"
+require "webauthn/public_key"
 
 module WebAuthn
   class SignatureVerificationError < VerificationError; end
@@ -42,7 +40,7 @@ module WebAuthn
     def verify(expected_challenge, expected_origin = nil, public_key:, sign_count:, user_verification: nil,
                rp_id: nil)
       super(expected_challenge, expected_origin, user_verification: user_verification, rp_id: rp_id)
-      verify_item(:signature, credential_cose_key(public_key))
+      verify_item(:signature, WebAuthn::PublicKey.deserialize(public_key))
       verify_item(:sign_count, sign_count)
 
       true
@@ -56,9 +54,9 @@ module WebAuthn
 
     attr_reader :authenticator_data_bytes, :signature
 
-    def valid_signature?(credential_cose_key)
+    def valid_signature?(webauthn_public_key)
       WebAuthn::SignatureVerifier
-        .new(credential_cose_key.alg, credential_cose_key.to_pkey)
+        .new(webauthn_public_key.cose_key.alg, webauthn_public_key.pkey)
         .verify(signature, authenticator_data_bytes + client_data.hash)
     end
 
@@ -68,29 +66,6 @@ module WebAuthn
         authenticator_data.sign_count > normalized_sign_count
       else
         true
-      end
-    end
-
-    def credential_cose_key(public_key)
-      if WebAuthn::AttestationStatement::FidoU2f::PublicKey.uncompressed_point?(public_key)
-        # Gem version v1.11.0 and lower, used to behave so that Credential#public_key
-        # returned an EC P-256 uncompressed point.
-        #
-        # Because of https://github.com/cedarcode/webauthn-ruby/issues/137 this was changed
-        # and Credential#public_key started returning the unchanged COSE_Key formatted
-        # credentialPublicKey (as in https://www.w3.org/TR/webauthn/#credentialpublickey).
-        #
-        # Given that the credential public key is expected to be stored long-term by the gem
-        # user and later be passed as the public_key argument in the
-        # AuthenticatorAssertionResponse.verify call, we then need to support the two formats.
-        COSE::Key::EC2.new(
-          alg: COSE::Algorithm.by_name("ES256").id,
-          crv: 1,
-          x: public_key[1..32],
-          y: public_key[33..-1]
-        )
-      else
-        COSE::Key.deserialize(public_key)
       end
     end
 

--- a/lib/webauthn/public_key.rb
+++ b/lib/webauthn/public_key.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "webauthn/attestation_statement/fido_u2f/public_key"
+require "cose/key"
+require "cose/algorithm"
+
+module WebAuthn
+  class PublicKey
+    def self.deserialize(public_key)
+      cose_key =
+        if WebAuthn::AttestationStatement::FidoU2f::PublicKey.uncompressed_point?(public_key)
+          # Gem version v1.11.0 and lower, used to behave so that Credential#public_key
+          # returned an EC P-256 uncompressed point.
+          #
+          # Because of https://github.com/cedarcode/webauthn-ruby/issues/137 this was changed
+          # and Credential#public_key started returning the unchanged COSE_Key formatted
+          # credentialPublicKey (as in https://www.w3.org/TR/webauthn/#credentialpublickey).
+          #
+          # Given that the credential public key is expected to be stored long-term by the gem
+          # user and later be passed as the public_key argument in the
+          # AuthenticatorAssertionResponse.verify call, we then need to support the two formats.
+          COSE::Key::EC2.new(
+            alg: COSE::Algorithm.by_name("ES256").id,
+            crv: 1,
+            x: public_key[1..32],
+            y: public_key[33..-1]
+          )
+        else
+          COSE::Key.deserialize(public_key)
+        end
+
+      new(cose_key: cose_key)
+    end
+
+    attr_reader :cose_key
+
+    def initialize(cose_key:)
+      @cose_key = cose_key
+    end
+
+    def pkey
+      @cose_key.to_pkey
+    end
+  end
+end

--- a/lib/webauthn/public_key.rb
+++ b/lib/webauthn/public_key.rb
@@ -41,5 +41,9 @@ module WebAuthn
     def pkey
       @cose_key.to_pkey
     end
+
+    def alg
+      @cose_key.alg
+    end
   end
 end

--- a/spec/webauthn/public_key_spec.rb
+++ b/spec/webauthn/public_key_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "webauthn/public_key"
+require "support/seeds"
+require "cose"
+require "openssl"
+
+RSpec.describe "PublicKey" do
+  let(:uncompressed_point_public_key) do
+    Base64.strict_decode64(seeds[:u2f_migration][:stored_credential][:public_key])
+  end
+  let(:cose_public_key) do
+    Base64.urlsafe_decode64(
+      "pQECAyYgASFYIPJKd_-Rl0QtQwbLggjGC_EbUFIMriCkdc2yuaukkBuNIlggaBsBjCwnMzFL7OUGJNm4b-HVpFNUa_NbsHGARuYKHfU"
+    )
+  end
+  let(:webauthn_public_key) { WebAuthn::PublicKey.deserialize(public_key) }
+
+  describe ".deserialize" do
+    context "when invalid public key" do
+      let(:public_key) { 'invalidinvalid' }
+
+      it "should fail" do
+        expect { webauthn_public_key }.to raise_error(CBOR::MalformedFormatError)
+      end
+    end
+  end
+
+  describe "#pkey" do
+    let(:pkey) { webauthn_public_key.pkey }
+
+    context "when public key stored in uncompressed point format" do
+      let(:public_key) { uncompressed_point_public_key }
+
+      it "should return ssl pkey" do
+        expect(pkey).to be_instance_of(OpenSSL::PKey::EC)
+      end
+    end
+
+    context "when public key stored in cose format" do
+      let(:public_key) { cose_public_key }
+
+      it "should return ssl pkey" do
+        expect(pkey).to be_instance_of(OpenSSL::PKey::EC)
+      end
+    end
+  end
+
+  describe "#cose_key" do
+    let(:cose_key) { webauthn_public_key.cose_key }
+
+    context "when public key stored in uncompressed point format" do
+      let(:public_key) { uncompressed_point_public_key }
+
+      it "should return EC2 cose key" do
+        expect(cose_key).to be_instance_of(COSE::Key::EC2)
+      end
+    end
+
+    context "when public key stored in cose format" do
+      let(:public_key) { cose_public_key }
+
+      it "should return cose key" do
+        expect(cose_key).to be_a(COSE::Key::Base)
+      end
+    end
+  end
+end

--- a/spec/webauthn/public_key_spec.rb
+++ b/spec/webauthn/public_key_spec.rb
@@ -67,4 +67,24 @@ RSpec.describe "PublicKey" do
       end
     end
   end
+
+  describe "#alg" do
+    let(:alg) { webauthn_public_key.alg }
+
+    context "when public key stored in uncompressed point format" do
+      let(:public_key) { uncompressed_point_public_key }
+
+      it "should return ES256 cose algorithm id" do
+        expect(alg).to eq(COSE::Algorithm.by_name("ES256").id)
+      end
+    end
+
+    context "when public key stored in cose format" do
+      let(:public_key) { cose_public_key }
+
+      it "should return cose algorithm id" do
+        expect(alg).to be_a(Integer)
+      end
+    end
+  end
 end


### PR DESCRIPTION
WebAuthn has some custom logic to account for backward compatibility on the deserialization of stored public keys in older formats. See [this comment](https://github.com/cedarcode/webauthn-ruby/blob/v2.0.0/lib/webauthn/authenticator_assertion_response.rb#L76).

Up until now, this logic is was not properly encapsulated so that it could be reused from other parts of the gem, or even to be used as a public API.

Motivated by https://github.com/cedarcode/webauthn-ruby/issues/222 and in collaboration with @padulafacundo  a new method is now exposed to be able to check that a stored public key abides by the expected formatting.
If `WebAuthn::PublicKey.deserialize(stored_public_key)` succeeds, then a user can be sure the key is valid.