### PR TITLE
test: patch in TPM conformance test behaviour

### DIFF
--- a/spec/conformance/conformance_patches.rb
+++ b/spec/conformance/conformance_patches.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "tpm/constants"
+
+::TPM.send(:remove_const, "VENDOR_IDS")
+::TPM::VENDOR_IDS = { "id:FFFFF1D0" => "FIDO Alliance" }.freeze

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -12,6 +12,7 @@ set show_exceptions: false
 
 require_relative 'mds_finder'
 require_relative 'conformance_cache_store'
+require_relative "conformance_patches"
 
 RP_NAME = "webauthn-ruby #{WebAuthn::VERSION} conformance test server"
 


### PR DESCRIPTION
There's only one valid manufacturing ID in conformance testing.

Fixes https://github.com/cedarcode/webauthn-ruby/pull/291#issuecomment-568765419