### PR TITLE
Support multiple relying parties

### DIFF
--- a/lib/webauthn/attestation_object.rb
+++ b/lib/webauthn/attestation_object.rb
@@ -17,7 +17,11 @@ module WebAuthn
     def self.from_map(map, relying_party)
       new(
         authenticator_data: WebAuthn::AuthenticatorData.deserialize(map["authData"]),
-        attestation_statement: WebAuthn::AttestationStatement.from(map["fmt"], map["attStmt"], relying_party),
+        attestation_statement: WebAuthn::AttestationStatement.from(
+          map["fmt"],
+          map["attStmt"],
+          relying_party: relying_party
+        )
       )
     end
 

--- a/lib/webauthn/attestation_object.rb
+++ b/lib/webauthn/attestation_object.rb
@@ -17,7 +17,7 @@ module WebAuthn
     def self.from_map(map, relying_party)
       new(
         authenticator_data: WebAuthn::AuthenticatorData.deserialize(map["authData"]),
-        attestation_statement: WebAuthn::AttestationStatement.from(map["fmt"], map["attStmt"], relying_party)
+        attestation_statement: WebAuthn::AttestationStatement.from(map["fmt"], map["attStmt"], relying_party),
       )
     end
 

--- a/lib/webauthn/attestation_object.rb
+++ b/lib/webauthn/attestation_object.rb
@@ -11,17 +11,17 @@ module WebAuthn
     extend Forwardable
 
     def self.deserialize(attestation_object)
-      from_map(CBOR.decode(attestation_object))
+      from_map(CBOR.decode(attestation_object), relying_party)
     end
 
-    def self.from_map(map)
+    def self.from_map(map, relying_party)
       new(
         authenticator_data: WebAuthn::AuthenticatorData.deserialize(map["authData"]),
-        attestation_statement: WebAuthn::AttestationStatement.from(map["fmt"], map["attStmt"])
+        attestation_statement: WebAuthn::AttestationStatement.from(map["fmt"], map["attStmt"], relying_party)
       )
     end
 
-    attr_reader :authenticator_data, :attestation_statement
+    attr_reader :authenticator_data, :attestation_statement, :relying_party
 
     def initialize(authenticator_data:, attestation_statement:)
       @authenticator_data = authenticator_data

--- a/lib/webauthn/attestation_object.rb
+++ b/lib/webauthn/attestation_object.rb
@@ -10,7 +10,7 @@ module WebAuthn
   class AttestationObject
     extend Forwardable
 
-    def self.deserialize(attestation_object)
+    def self.deserialize(attestation_object, relying_party)
       from_map(CBOR.decode(attestation_object), relying_party)
     end
 

--- a/lib/webauthn/attestation_statement.rb
+++ b/lib/webauthn/attestation_statement.rb
@@ -28,11 +28,11 @@ module WebAuthn
       ATTESTATION_FORMAT_TPM => WebAuthn::AttestationStatement::TPM
     }.freeze
 
-    def self.from(format, statement)
+    def self.from(format, statement, relying_party)
       klass = FORMAT_TO_CLASS[format]
 
       if klass
-        klass.new(statement)
+        klass.new(statement, relying_party)
       else
         raise(FormatNotSupportedError, "Unsupported attestation format '#{format}'")
       end

--- a/lib/webauthn/attestation_statement.rb
+++ b/lib/webauthn/attestation_statement.rb
@@ -28,11 +28,11 @@ module WebAuthn
       ATTESTATION_FORMAT_TPM => WebAuthn::AttestationStatement::TPM
     }.freeze
 
-    def self.from(format, statement, relying_party)
+    def self.from(format, statement, relying_party: RelyingParty.new)
       klass = FORMAT_TO_CLASS[format]
 
       if klass
-        klass.new(statement, relying_party)
+        klass.new(statement, relying_party: relying_party)
       else
         raise(FormatNotSupportedError, "Unsupported attestation format '#{format}'")
       end

--- a/lib/webauthn/attestation_statement.rb
+++ b/lib/webauthn/attestation_statement.rb
@@ -28,7 +28,7 @@ module WebAuthn
       ATTESTATION_FORMAT_TPM => WebAuthn::AttestationStatement::TPM
     }.freeze
 
-    def self.from(format, statement, relying_party: RelyingParty.new)
+    def self.from(format, statement, relying_party: WebAuthn.configuration.relying_party)
       klass = FORMAT_TO_CLASS[format]
 
       if klass

--- a/lib/webauthn/attestation_statement.rb
+++ b/lib/webauthn/attestation_statement.rb
@@ -32,7 +32,7 @@ module WebAuthn
       klass = FORMAT_TO_CLASS[format]
 
       if klass
-        klass.new(statement, relying_party: relying_party)
+        klass.new(statement, relying_party)
       else
         raise(FormatNotSupportedError, "Unsupported attestation format '#{format}'")
       end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -26,7 +26,7 @@ module WebAuthn
     class Base
       AAGUID_EXTENSION_OID = "1.3.6.1.4.1.45724.1.1.4"
 
-      def initialize(statement, relying_party: RelyingParty.new)
+      def initialize(statement, relying_party: WebAuthn.configuration)
         @statement = statement
         @relying_party = relying_party
       end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -26,7 +26,7 @@ module WebAuthn
     class Base
       AAGUID_EXTENSION_OID = "1.3.6.1.4.1.45724.1.1.4"
 
-      def initialize(statement, relying_party: WebAuthn.configuration.relying_party)
+      def initialize(statement, relying_party = WebAuthn.configuration.relying_party)
         @statement = statement
         @relying_party = relying_party
       end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -26,7 +26,7 @@ module WebAuthn
     class Base
       AAGUID_EXTENSION_OID = "1.3.6.1.4.1.45724.1.1.4"
 
-      def initialize(statement, relying_party)
+      def initialize(statement, relying_party: RelyingParty.new)
         @statement = statement
         @relying_party = relying_party
       end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -26,7 +26,7 @@ module WebAuthn
     class Base
       AAGUID_EXTENSION_OID = "1.3.6.1.4.1.45724.1.1.4"
 
-      def initialize(statement, relying_party: WebAuthn.configuration)
+      def initialize(statement, relying_party: WebAuthn.configuration.relying_party)
         @statement = statement
         @relying_party = relying_party
       end

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -29,17 +29,12 @@ module WebAuthn
 
     attr_reader :user_handle
 
-    def initialize(authenticator_data:,
-                   signature:,
-                   user_handle: nil,
-                   relying_party: WebAuthn.configuration.relying_party,
-                   **options)
+    def initialize(authenticator_data:, signature:, user_handle: nil, **options)
       super(**options)
 
       @authenticator_data_bytes = authenticator_data
       @signature = signature
       @user_handle = user_handle
-      @relying_party = relying_party
     end
 
     def verify(expected_challenge, expected_origin = nil, public_key:, sign_count:, user_verification: nil, rp_id: nil)
@@ -56,7 +51,7 @@ module WebAuthn
 
     private
 
-    attr_reader :authenticator_data_bytes, :signature, :relying_party
+    attr_reader :authenticator_data_bytes, :signature
 
     def valid_signature?(webauthn_public_key)
       webauthn_public_key.verify(signature, authenticator_data_bytes + client_data.hash)

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -27,7 +27,7 @@ module WebAuthn
       )
     end
 
-    attr_reader :user_handle, :relying_party
+    attr_reader :user_handle
 
     def initialize(authenticator_data:, signature:, user_handle: nil, relying_party: RelyingParty.new, **options)
       super(**options)
@@ -52,7 +52,7 @@ module WebAuthn
 
     private
 
-    attr_reader :authenticator_data_bytes, :signature
+    attr_reader :authenticator_data_bytes, :signature, :relying_party
 
     def valid_signature?(webauthn_public_key)
       webauthn_public_key.verify(signature, authenticator_data_bytes + client_data.hash)

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -10,7 +10,7 @@ module WebAuthn
   class SignCountVerificationError < VerificationError; end
 
   class AuthenticatorAssertionResponse < AuthenticatorResponse
-    def self.from_client(response, relying_party: RelyingParty.new)
+    def self.from_client(response, relying_party: WebAuthn.configuration)
       encoder = relying_party.encoder
 
       user_handle =
@@ -29,7 +29,7 @@ module WebAuthn
 
     attr_reader :user_handle
 
-    def initialize(authenticator_data:, signature:, user_handle: nil, relying_party: RelyingParty.new, **options)
+    def initialize(authenticator_data:, signature:, user_handle: nil, relying_party: WebAuthn.configuration, **options)
       super(**options)
 
       @authenticator_data_bytes = authenticator_data

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -10,7 +10,7 @@ module WebAuthn
   class SignCountVerificationError < VerificationError; end
 
   class AuthenticatorAssertionResponse < AuthenticatorResponse
-    def self.from_client(response, relying_party: WebAuthn.configuration)
+    def self.from_client(response, relying_party: WebAuthn.configuration.relying_party)
       encoder = relying_party.encoder
 
       user_handle =
@@ -29,7 +29,11 @@ module WebAuthn
 
     attr_reader :user_handle
 
-    def initialize(authenticator_data:, signature:, user_handle: nil, relying_party: WebAuthn.configuration, **options)
+    def initialize(authenticator_data:,
+                   signature:,
+                   user_handle: nil,
+                   relying_party: WebAuthn.configuration.relying_party,
+                   **options)
       super(**options)
 
       @authenticator_data_bytes = authenticator_data

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -10,8 +10,8 @@ module WebAuthn
   class SignCountVerificationError < VerificationError; end
 
   class AuthenticatorAssertionResponse < AuthenticatorResponse
-    def self.from_client(response)
-      encoder = WebAuthn.configuration.encoder
+    def self.from_client(response, relying_party: RelyingParty.new)
+      encoder = relying_party.encoder
 
       user_handle =
         if response["userHandle"]
@@ -22,18 +22,20 @@ module WebAuthn
         authenticator_data: encoder.decode(response["authenticatorData"]),
         client_data_json: encoder.decode(response["clientDataJSON"]),
         signature: encoder.decode(response["signature"]),
-        user_handle: user_handle
+        user_handle: user_handle,
+        relying_party: relying_party
       )
     end
 
-    attr_reader :user_handle
+    attr_reader :user_handle, :relying_party
 
-    def initialize(authenticator_data:, signature:, user_handle: nil, **options)
+    def initialize(authenticator_data:, signature:, user_handle: nil, relying_party: RelyingParty.new, **options)
       super(**options)
 
       @authenticator_data_bytes = authenticator_data
       @signature = signature
       @user_handle = user_handle
+      @relying_party = relying_party
     end
 
     def verify(expected_challenge, expected_origin = nil, public_key:, sign_count:, user_verification: nil, rp_id: nil)

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -40,6 +40,7 @@ module WebAuthn
     def verify(expected_challenge, expected_origin = nil, user_verification: nil, rp_id: nil)
       super
 
+      verify_item(:credential_algorithm)
       verify_item(:attested_credential)
       if relying_party.verify_attestation_statement
         verify_item(:attestation_statement)
@@ -69,6 +70,10 @@ module WebAuthn
 
     def type
       WebAuthn::TYPES[:create]
+    end
+
+    def valid_credential_algorithm?
+      relying_party.algorithms.include?(authenticator_data.credential.algorithm)
     end
 
     def valid_attested_credential?

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -65,7 +65,7 @@ module WebAuthn
 
     private
 
-    attr_reader :relying_party
+    attr_reader :attestation_object_bytes, :relying_party
 
     def type
       WebAuthn::TYPES[:create]

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -28,7 +28,7 @@ module WebAuthn
       )
     end
 
-    attr_reader :attestation_type, :attestation_trust_path, :relying_party
+    attr_reader :attestation_type, :attestation_trust_path
 
     def initialize(attestation_object:, relying_party: WebAuthn.configuration.relying_party, **options)
       super(**options)
@@ -65,7 +65,7 @@ module WebAuthn
 
     private
 
-    attr_reader :attestation_object_bytes
+    attr_reader :attestation_object, :relying_party
 
     def type
       WebAuthn::TYPES[:create]

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -18,7 +18,7 @@ module WebAuthn
   class AuthenticatorAttestationResponse < AuthenticatorResponse
     extend Forwardable
 
-    def self.from_client(response, relying_party: RelyingParty.new)
+    def self.from_client(response, relying_party: WebAuthn.configuration.relying_party)
       encoder = relying_party.encoder
 
       new(
@@ -30,7 +30,7 @@ module WebAuthn
 
     attr_reader :attestation_type, :attestation_trust_path, :relying_party
 
-    def initialize(attestation_object:, relying_party: RelyingParty.new, **options)
+    def initialize(attestation_object:, relying_party: WebAuthn.configuration, **options)
       super(**options)
 
       @attestation_object_bytes = attestation_object

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -30,7 +30,7 @@ module WebAuthn
 
     attr_reader :attestation_type, :attestation_trust_path
 
-    def initialize(attestation_object:, relying_party: WebAuthn.configuration.relying_party, **options)
+    def initialize(attestation_object:, **options)
       super(**options)
 
       @attestation_object_bytes = attestation_object
@@ -65,7 +65,7 @@ module WebAuthn
 
     private
 
-    attr_reader :attestation_object, :relying_party
+    attr_reader :relying_party
 
     def type
       WebAuthn::TYPES[:create]

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -30,7 +30,7 @@ module WebAuthn
 
     attr_reader :attestation_type, :attestation_trust_path, :relying_party
 
-    def initialize(attestation_object:, relying_party: WebAuthn.configuration, **options)
+    def initialize(attestation_object:, relying_party: WebAuthn.configuration.relying_party, **options)
       super(**options)
 
       @attestation_object_bytes = attestation_object

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -40,7 +40,6 @@ module WebAuthn
     def verify(expected_challenge, expected_origin = nil, user_verification: nil, rp_id: nil)
       super
 
-      verify_item(:credential_algorithm)
       verify_item(:attested_credential)
       if relying_party.verify_attestation_statement
         verify_item(:attestation_statement)
@@ -72,12 +71,9 @@ module WebAuthn
       WebAuthn::TYPES[:create]
     end
 
-    def valid_credential_algorithm?
-      relying_party.algorithms.include?(authenticator_data.credential.algorithm)
-    end
-
     def valid_attested_credential?
-      attestation_object.valid_attested_credential?
+      attestation_object.valid_attested_credential? &&
+        relying_party.algorithms.include?(authenticator_data.credential.algorithm)
     end
 
     def valid_attestation_statement?

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -20,8 +20,9 @@ module WebAuthn
   class UserVerifiedVerificationError < VerificationError; end
 
   class AuthenticatorResponse
-    def initialize(client_data_json:)
+    def initialize(client_data_json:, relying_party: WebAuthn.configuration.relying_party)
       @client_data_json = client_data_json
+      @relying_party = relying_party
     end
 
     def verify(expected_challenge, expected_origin = nil, user_verification: nil, rp_id: nil)
@@ -58,7 +59,7 @@ module WebAuthn
 
     private
 
-    attr_reader :client_data_json
+    attr_reader :client_data_json, :relying_party
 
     def verify_item(item, *args)
       if send("valid_#{item}?", *args)

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -25,8 +25,8 @@ module WebAuthn
     end
 
     def verify(expected_challenge, expected_origin = nil, user_verification: nil, rp_id: nil)
-      expected_origin ||= WebAuthn.configuration.origin || raise("Unspecified expected origin")
-      rp_id ||= WebAuthn.configuration.rp_id
+      expected_origin ||= relying_party.origin || raise("Unspecified expected origin")
+      rp_id ||= relying_party.id
 
       verify_item(:type)
       verify_item(:token_binding)
@@ -35,7 +35,7 @@ module WebAuthn
       verify_item(:authenticator_data)
       verify_item(:rp_id, rp_id || rp_id_from_origin(expected_origin))
 
-      if !WebAuthn.configuration.silent_authentication
+      if !relying_party.silent_authentication
         verify_item(:user_presence)
       end
 

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -22,10 +22,6 @@ module WebAuthn
                    :encoding=,
                    :origin,
                    :origin=,
-                   :rp_id,
-                   :rp_id=,
-                   :rp_name,
-                   :rp_name=,
                    :verify_attestation_statement,
                    :verify_attestation_statement=,
                    :credential_options_timeout,
@@ -43,6 +39,22 @@ module WebAuthn
 
     def initialize
       @relying_party = RelyingParty.new
+    end
+
+    def rp_name
+      relying_party.name
+    end
+
+    def rp_name=(name)
+      relying_party.name = name
+    end
+
+    def rp_id
+      relying_party.id
+    end
+
+    def rp_id=(id)
+      relying_party.id = id
     end
   end
 end

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -37,11 +37,9 @@ module WebAuthn
                    :attestation_root_certificates_finders,
                    :attestation_root_certificates_finders=,
                    :encoder,
-                   :encoder=,
-                   :id,
-                   :id=,
-                   :name,
-                   :name=
+                   :encoder=
+
+    attr_reader :relying_party
 
     def initialize
       @relying_party = RelyingParty.new

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -1,13 +1,50 @@
 # frozen_string_literal: true
 
+require 'forwardable'
 require 'webauthn/relying_party'
 
 module WebAuthn
   def self.configuration
-    @configuration ||= RelyingParty.new
+    @configuration ||= Configuration.new
   end
 
   def self.configure
     yield(configuration)
+  end
+
+  class Configuration
+    extend Forwardable
+
+    def_delegators :@relying_party,
+                   :algorithms,
+                   :algorithms=,
+                   :encoding,
+                   :encoding=,
+                   :origin,
+                   :origin=,
+                   :rp_id,
+                   :rp_id=,
+                   :rp_name,
+                   :rp_name=,
+                   :verify_attestation_statement,
+                   :verify_attestation_statement=,
+                   :credential_options_timeout,
+                   :credential_options_timeout=,
+                   :silent_authentication,
+                   :silent_authentication=,
+                   :acceptable_attestation_types,
+                   :acceptable_attestation_types=,
+                   :attestation_root_certificates_finders,
+                   :attestation_root_certificates_finders=,
+                   :encoder,
+                   :encoder=,
+                   :id,
+                   :id=,
+                   :name,
+                   :name=
+
+    def initialize
+      @relying_party = RelyingParty.new
+    end
   end
 end

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -1,66 +1,13 @@
 # frozen_string_literal: true
 
-require "openssl"
-require "webauthn/encoder"
-require "webauthn/error"
+require 'webauthn/relying_party'
 
 module WebAuthn
   def self.configuration
-    @configuration ||= Configuration.new
+    @configuration ||= RelyingParty.new
   end
 
   def self.configure
     yield(configuration)
-  end
-
-  class RootCertificateFinderNotSupportedError < Error; end
-
-  class Configuration
-    def self.if_pss_supported(algorithm)
-      OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss) ? algorithm : nil
-    end
-
-    DEFAULT_ALGORITHMS = ["ES256", if_pss_supported("PS256"), "RS256"].compact.freeze
-
-    attr_accessor :algorithms
-    attr_accessor :encoding
-    attr_accessor :origin
-    attr_accessor :rp_id
-    attr_accessor :rp_name
-    attr_accessor :verify_attestation_statement
-    attr_accessor :credential_options_timeout
-    attr_accessor :silent_authentication
-    attr_accessor :acceptable_attestation_types
-    attr_reader :attestation_root_certificates_finders
-
-    def initialize
-      @algorithms = DEFAULT_ALGORITHMS.dup
-      @encoding = WebAuthn::Encoder::STANDARD_ENCODING
-      @verify_attestation_statement = true
-      @credential_options_timeout = 120000
-      @silent_authentication = false
-      @acceptable_attestation_types = ['None', 'Self', 'Basic', 'AttCA', 'Basic_or_AttCA']
-      @attestation_root_certificates_finders = []
-    end
-
-    # This is the user-data encoder.
-    # Used to decode user input and to encode data provided to the user.
-    def encoder
-      @encoder ||= WebAuthn::Encoder.new(encoding)
-    end
-
-    def attestation_root_certificates_finders=(finders)
-      if !finders.respond_to?(:each)
-        finders = [finders]
-      end
-
-      finders.each do |finder|
-        unless finder.respond_to?(:find)
-          raise RootCertificateFinderNotSupportedError, "Finder must implement `find` method"
-        end
-      end
-
-      @attestation_root_certificates_finders = finders
-    end
   end
 end

--- a/lib/webauthn/credential.rb
+++ b/lib/webauthn/credential.rb
@@ -16,11 +16,11 @@ module WebAuthn
       WebAuthn::PublicKeyCredential::RequestOptions.new(**keyword_arguments)
     end
 
-    def self.from_create(credential, relying_party: RelyingParty.new)
+    def self.from_create(credential, relying_party: WebAuthn.configuration)
       WebAuthn::PublicKeyCredentialWithAttestation.from_client(credential, relying_party: relying_party)
     end
 
-    def self.from_get(credential, relying_party: RelyingParty.new)
+    def self.from_get(credential, relying_party: WebAuthn.configuration)
       WebAuthn::PublicKeyCredentialWithAssertion.from_client(credential, relying_party: relying_party)
     end
   end

--- a/lib/webauthn/credential.rb
+++ b/lib/webauthn/credential.rb
@@ -4,6 +4,7 @@ require "webauthn/public_key_credential/creation_options"
 require "webauthn/public_key_credential/request_options"
 require "webauthn/public_key_credential_with_assertion"
 require "webauthn/public_key_credential_with_attestation"
+require "webauthn/relying_party"
 
 module WebAuthn
   module Credential
@@ -15,12 +16,12 @@ module WebAuthn
       WebAuthn::PublicKeyCredential::RequestOptions.new(**keyword_arguments)
     end
 
-    def self.from_create(credential)
-      WebAuthn::PublicKeyCredentialWithAttestation.from_client(credential)
+    def self.from_create(credential, relying_party: RelyingParty.new)
+      WebAuthn::PublicKeyCredentialWithAttestation.from_client(credential, relying_party: relying_party)
     end
 
-    def self.from_get(credential)
-      WebAuthn::PublicKeyCredentialWithAssertion.from_client(credential)
+    def self.from_get(credential, relying_party: RelyingParty.new)
+      WebAuthn::PublicKeyCredentialWithAssertion.from_client(credential, relying_party: relying_party)
     end
   end
 end

--- a/lib/webauthn/credential.rb
+++ b/lib/webauthn/credential.rb
@@ -16,11 +16,11 @@ module WebAuthn
       WebAuthn::PublicKeyCredential::RequestOptions.new(**keyword_arguments)
     end
 
-    def self.from_create(credential, relying_party: WebAuthn.configuration)
+    def self.from_create(credential, relying_party: WebAuthn.configuration.relying_party)
       WebAuthn::PublicKeyCredentialWithAttestation.from_client(credential, relying_party: relying_party)
     end
 
-    def self.from_get(credential, relying_party: WebAuthn.configuration)
+    def self.from_get(credential, relying_party: WebAuthn.configuration.relying_party)
       WebAuthn::PublicKeyCredentialWithAssertion.from_client(credential, relying_party: relying_party)
     end
   end

--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -10,7 +10,7 @@ module WebAuthn
   class FakeClient
     TYPES = { create: "webauthn.create", get: "webauthn.get" }.freeze
 
-    attr_reader :origin, :token_binding
+    attr_reader :origin, :token_binding, :encoding
 
     def initialize(
       origin = fake_origin,
@@ -104,7 +104,7 @@ module WebAuthn
 
     private
 
-    attr_reader :authenticator, :encoding
+    attr_reader :authenticator
 
     def data_json_for(method, challenge)
       data = {

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -6,7 +6,7 @@ module WebAuthn
   class PublicKeyCredential
     attr_reader :type, :id, :raw_id, :client_extension_outputs, :response
 
-    def self.from_client(credential, relying_party: WebAuthn.configuration)
+    def self.from_client(credential, relying_party: WebAuthn.configuration.relying_party)
       new(
         type: credential["type"],
         id: credential["id"],

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -12,16 +12,25 @@ module WebAuthn
         id: credential["id"],
         raw_id: relying_party.encoder.decode(credential["rawId"]),
         client_extension_outputs: credential["clientExtensionResults"],
-        response: response_class.from_client(credential["response"], relying_party: relying_party)
+        response: response_class.from_client(credential["response"], relying_party: relying_party),
+        encoder: relying_party.encoder
       )
     end
 
-    def initialize(type:, id:, raw_id:, client_extension_outputs: {}, response:)
+    def initialize(
+      type:,
+      id:,
+      raw_id:,
+      response:,
+      client_extension_outputs: {},
+      encoder: WebAuthn.configuration.encoder
+    )
       @type = type
       @id = id
       @raw_id = raw_id
       @client_extension_outputs = client_extension_outputs
       @response = response
+      @encoder = encoder
     end
 
     def verify(*_args)
@@ -41,6 +50,8 @@ module WebAuthn
 
     private
 
+    attr_reader :encoder
+
     def valid_type?
       type == TYPE_PUBLIC_KEY
     end
@@ -51,10 +62,6 @@ module WebAuthn
 
     def authenticator_data
       response&.authenticator_data
-    end
-
-    def encoder
-      WebAuthn.configuration.encoder
     end
   end
 end

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -6,13 +6,13 @@ module WebAuthn
   class PublicKeyCredential
     attr_reader :type, :id, :raw_id, :client_extension_outputs, :response
 
-    def self.from_client(credential)
+    def self.from_client(credential, relying_party: RelyingParty.new)
       new(
         type: credential["type"],
         id: credential["id"],
-        raw_id: WebAuthn.configuration.encoder.decode(credential["rawId"]),
+        raw_id: relying_party.encoder.decode(credential["rawId"]),
         client_extension_outputs: credential["clientExtensionResults"],
-        response: response_class.from_client(credential["response"])
+        response: response_class.from_client(credential["response"], relying_party: relying_party)
       )
     end
 

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -6,7 +6,7 @@ module WebAuthn
   class PublicKeyCredential
     attr_reader :type, :id, :raw_id, :client_extension_outputs, :response
 
-    def self.from_client(credential, relying_party: RelyingParty.new)
+    def self.from_client(credential, relying_party: WebAuthn.configuration)
       new(
         type: credential["type"],
         id: credential["id"],

--- a/lib/webauthn/public_key_credential/creation_options.rb
+++ b/lib/webauthn/public_key_credential/creation_options.rb
@@ -39,8 +39,8 @@ module WebAuthn
 
         @rp =
           if rp.is_a?(Hash)
-            rp[:name] ||= configuration.rp_name
-            rp[:id] ||= configuration.rp_id
+            rp[:name] ||= relying_party.name
+            rp[:id] ||= relying_party.id
 
             RPEntity.new(**rp)
           else
@@ -76,7 +76,7 @@ module WebAuthn
       end
 
       def pub_key_cred_params_from_algs
-        Array(algs || configuration.algorithms).map do |alg|
+        Array(algs || relying_party.algorithms).map do |alg|
           alg_id =
             if alg.is_a?(String) || alg.is_a?(Symbol)
               COSE::Algorithm.by_name(alg.to_s).id

--- a/lib/webauthn/public_key_credential/options.rb
+++ b/lib/webauthn/public_key_credential/options.rb
@@ -10,7 +10,7 @@ module WebAuthn
 
       attr_reader :timeout, :extensions
 
-      def initialize(timeout: nil, extensions: nil, relying_party: RelyingParty.new)
+      def initialize(timeout: nil, extensions: nil, relying_party: WebAuthn.configuration)
         @relying_party = relying_party
         @timeout = timeout || default_timeout
         @extensions = extensions

--- a/lib/webauthn/public_key_credential/options.rb
+++ b/lib/webauthn/public_key_credential/options.rb
@@ -10,8 +10,9 @@ module WebAuthn
 
       attr_reader :timeout, :extensions
 
-      def initialize(timeout: default_timeout, extensions: nil)
-        @timeout = timeout
+      def initialize(timeout: nil, extensions: nil, relying_party: RelyingParty.new)
+        @relying_party = relying_party
+        @timeout = timeout || default_timeout
         @extensions = extensions
       end
 
@@ -49,7 +50,7 @@ module WebAuthn
       end
 
       def encoder
-        WebAuthn.configuration.encoder
+        configuration.encoder
       end
 
       def raw_challenge
@@ -61,7 +62,7 @@ module WebAuthn
       end
 
       def configuration
-        WebAuthn.configuration
+        @relying_party
       end
 
       def as_public_key_descriptors(ids)

--- a/lib/webauthn/public_key_credential/options.rb
+++ b/lib/webauthn/public_key_credential/options.rb
@@ -10,7 +10,7 @@ module WebAuthn
 
       attr_reader :timeout, :extensions
 
-      def initialize(timeout: nil, extensions: nil, relying_party: WebAuthn.configuration)
+      def initialize(timeout: nil, extensions: nil, relying_party: WebAuthn.configuration.relying_party)
         @relying_party = relying_party
         @timeout = timeout || default_timeout
         @extensions = extensions

--- a/lib/webauthn/public_key_credential/options.rb
+++ b/lib/webauthn/public_key_credential/options.rb
@@ -8,7 +8,7 @@ module WebAuthn
     class Options
       CHALLENGE_LENGTH = 32
 
-      attr_reader :timeout, :extensions
+      attr_reader :timeout, :extensions, :relying_party
 
       def initialize(timeout: nil, extensions: nil, relying_party: WebAuthn.configuration.relying_party)
         @relying_party = relying_party
@@ -50,7 +50,7 @@ module WebAuthn
       end
 
       def encoder
-        configuration.encoder
+        relying_party.encoder
       end
 
       def raw_challenge
@@ -58,11 +58,7 @@ module WebAuthn
       end
 
       def default_timeout
-        configuration.credential_options_timeout
-      end
-
-      def configuration
-        @relying_party
+        relying_party.credential_options_timeout
       end
 
       def as_public_key_descriptors(ids)

--- a/lib/webauthn/public_key_credential/request_options.rb
+++ b/lib/webauthn/public_key_credential/request_options.rb
@@ -10,7 +10,7 @@ module WebAuthn
       def initialize(rp_id: nil, allow_credentials: nil, allow: nil, user_verification: nil, **keyword_arguments)
         super(**keyword_arguments)
 
-        @rp_id = rp_id || configuration.rp_id
+        @rp_id = rp_id || relying_party.id
         @allow_credentials = allow_credentials
         @allow = allow
         @user_verification = user_verification

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -94,6 +94,7 @@ module WebAuthn
         authenticator_selection: params["authenticatorSelection"],
         exclude: exclude,
         extensions: params["extensions"],
+        rp: to_hash,
         user: user
       )
     end
@@ -107,6 +108,7 @@ module WebAuthn
       WebAuthn::Credential.options_for_get(
         allow: allow,
         extensions: params["extensions"],
+        rp_id: id,
         user_verification: params["userVerification"]
       )
     end
@@ -119,6 +121,15 @@ module WebAuthn
         sign_count: sign_count,
         user_verification: user_verification
       )
+    end
+
+    private
+
+    def to_hash
+      {
+        id: id,
+        name: name
+      }
     end
   end
 end

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -39,9 +39,15 @@ module WebAuthn
       @attestation_root_certificates_finders = attestation_root_certificates_finders
     end
 
-    attr_accessor :algorithms, :encoding, :origin, :id, :name,
-                  :verify_attestation_statement, :credential_options_timeout,
-                  :silent_authentication, :acceptable_attestation_types
+    attr_accessor :algorithms,
+                  :encoding,
+                  :origin,
+                  :id,
+                  :name,
+                  :verify_attestation_statement,
+                  :credential_options_timeout,
+                  :silent_authentication,
+                  :acceptable_attestation_types
 
     attr_reader :attestation_root_certificates_finders
 

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -36,7 +36,7 @@ module WebAuthn
       @credential_options_timeout = credential_options_timeout
       @silent_authentication = silent_authentication
       @acceptable_attestation_types = acceptable_attestation_types
-      @attestation_root_certificates_finders = attestation_root_certificates_finders
+      self.attestation_root_certificates_finders = attestation_root_certificates_finders
     end
 
     attr_accessor :algorithms,

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -45,11 +45,6 @@ module WebAuthn
 
     attr_reader :attestation_root_certificates_finders
 
-    alias rp_name  name
-    alias rp_name= name=
-    alias rp_id    id
-    alias rp_id=   id=
-
     # This is the user-data encoder.
     # Used to decode user input and to encode data provided to the user.
     def encoder

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "webauthn/credential"
+
+module WebAuthn
+  class RelyingParty
+    def initialize(
+      algorithms: nil, encoding: nil, origin: nil, id: nil, name: nil,
+      verify_attestation_statement: nil, credential_options_timeout: nil,
+      silent_authentication: nil, acceptable_attestation_types: nil,
+      attestation_root_certificates_finders: nil
+    )
+      @algorithms = algorithms
+      @encoding = encoding
+      @origin = origin
+      @id = id
+      @name = name
+      @verify_attestation_statement = verify_attestation_statement
+      @credential_options_timeout = credential_options_timeout
+      @silent_authentication = silent_authentication
+      @acceptable_attestation_types = acceptable_attestation_types
+      @attestation_root_certificates_finders = attestation_root_certificates_finders
+    end
+
+    attr_writer :algorithms, :encoding, :origin, :id, :name,
+                :verify_attestation_statement, :credential_options_timeout,
+                :silent_authentication, :acceptable_attestation_types
+
+    def algorithms
+      @algorithms || WebAuthn.configuration.algorithms
+    end
+
+    def encoding
+      @encoding || WebAuthn.configuration.encoding
+    end
+
+    def origin
+      @origin || WebAuthn.configuration.origin
+    end
+
+    def id
+      @id || WebAuthn.configuration.rp_id
+    end
+
+    def name
+      @name || WebAuthn.configuration.rp_name
+    end
+
+    def verify_attestation_statement
+      @verify_attestation_statement || WebAuthn.configuration.verify_attestation_statement
+    end
+
+    def credential_options_timeout
+      @credential_options_timeout || WebAuthn.configuration.credential_options_timeout
+    end
+
+    def silent_authentication
+      @silent_authentication || WebAuthn.configuration.silent_authentication
+    end
+
+    def acceptable_attestation_types
+      @acceptable_attestation_types || WebAuthn.configuration.acceptable_attestation_types
+    end
+
+    def attestation_root_certificates_finders
+      @attestation_root_certificates_finders || WebAuthn.configuration.attestation_root_certificates_finders
+    end
+
+    def attestation_root_certificates_finders=(finders)
+      if !finders.respond_to?(:each)
+        finders = [finders]
+      end
+
+      finders.each do |finder|
+        unless finder.respond_to?(:find)
+          raise RootCertificateFinderNotSupportedError, "Finder must implement `find` method"
+        end
+      end
+
+      @attestation_root_certificates_finders = finders
+    end
+
+    def generate_user_id
+      WebAuthn.generate_user_id
+    end
+
+    def encoder
+      @encoder ||= WebAuthn::Encoder.new(encoding)
+    end
+
+    def options_for_registration(params, user:, exclude:)
+      WebAuthn::Credential.options_for_create(
+        attestation: params["attestation"],
+        authenticator_selection: params["authenticatorSelection"],
+        exclude: exclude,
+        extensions: params["extensions"],
+        user: user
+      )
+    end
+
+    def verify_registration(params, challenge, user_verification: nil)
+      credential = WebAuthn::Credential.from_create(params, relying_party: self)
+      credential if credential.verify(challenge, user_verification: user_verification)
+    end
+
+    def options_for_authentication(params, allow:)
+      WebAuthn::Credential.options_for_get(
+        allow: allow,
+        extensions: params["extensions"],
+        user_verification: params["userVerification"]
+      )
+    end
+
+    def verify_authentication(params, challenge, public_key:, sign_count:, user_verification:)
+      credential = WebAuthn::Credential.from_get(params, relying_party: self)
+      credential if credential.verify(
+        challenge,
+        public_key: public_key,
+        sign_count: sign_count,
+        user_verification: user_verification
+      )
+    end
+  end
+end

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -93,18 +93,25 @@ module WebAuthn
       )
     end
 
-    def verify_authentication(raw_credential, challenge, user_verification: nil, &block)
+    def verify_authentication(
+      raw_credential,
+      challenge,
+      user_verification: nil,
+      public_key: nil,
+      sign_count: nil,
+      &block
+    )
       webauthn_credential = WebAuthn::Credential.from_get(raw_credential, relying_party: self)
 
-      stored_credential = yield(webauthn_credential)
+      stored_credential = yield(webauthn_credential) if block_given?
 
       if webauthn_credential.verify(
         challenge,
-        public_key: stored_credential.public_key,
-        sign_count: stored_credential.sign_count,
+        public_key: public_key || stored_credential.public_key,
+        sign_count: sign_count || stored_credential.sign_count,
         user_verification: user_verification
       )
-        webauthn_credential
+        block_given? ? [webauthn_credential, stored_credential] : webauthn_credential
       end
     end
   end

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -71,33 +71,27 @@ module WebAuthn
       @attestation_root_certificates_finders = finders
     end
 
-    def options_for_registration(params, user:, exclude:)
+    def options_for_registration(**keyword_arguments)
       WebAuthn::Credential.options_for_create(
-        attestation: params["attestation"],
-        authenticator_selection: params["authenticatorSelection"],
-        exclude: exclude,
-        extensions: params["extensions"],
-        relying_party: self,
-        user: user
+        **keyword_arguments,
+        relying_party: self
       )
     end
 
-    def verify_registration(params, challenge, user_verification: nil)
-      credential = WebAuthn::Credential.from_create(params, relying_party: self)
+    def verify_registration(raw_credential, challenge, user_verification: nil)
+      credential = WebAuthn::Credential.from_create(raw_credential, relying_party: self)
       credential if credential.verify(challenge, user_verification: user_verification)
     end
 
-    def options_for_authentication(params, allow:)
+    def options_for_authentication(**keyword_arguments)
       WebAuthn::Credential.options_for_get(
-        allow: allow,
-        extensions: params["extensions"],
-        relying_party: self,
-        user_verification: params["userVerification"]
+        **keyword_arguments,
+        relying_party: self
       )
     end
 
-    def verify_authentication(params, challenge, public_key:, sign_count:, user_verification:)
-      credential = WebAuthn::Credential.from_get(params, relying_party: self)
+    def verify_authentication(raw_credential, challenge, public_key:, sign_count:, user_verification: nil)
+      credential = WebAuthn::Credential.from_get(raw_credential, relying_party: self)
       credential if credential.verify(
         challenge,
         public_key: public_key,

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -98,8 +98,7 @@ module WebAuthn
       challenge,
       user_verification: nil,
       public_key: nil,
-      sign_count: nil,
-      &block
+      sign_count: nil
     )
       webauthn_credential = WebAuthn::Credential.from_get(raw_credential, relying_party: self)
 

--- a/spec/conformance/conformance_cache_store.rb
+++ b/spec/conformance/conformance_cache_store.rb
@@ -6,6 +6,12 @@ require "zip"
 
 class ConformanceCacheStore < FidoMetadata::TestCacheStore
   FILENAME = "metadata.zip"
+  attr_reader :origin
+
+  def initialize(origin)
+    super()
+    @origin = origin
+  end
 
   def setup_authenticators
     puts("#{FILENAME} not found, this will affect Metadata Service Test results.") unless File.exist?(FILENAME)
@@ -23,7 +29,7 @@ class ConformanceCacheStore < FidoMetadata::TestCacheStore
 
     response = Net::HTTP.post(
       URI("https://fidoalliance.co.nz/mds/getEndpoints"),
-      { endpoint: WebAuthn.configuration.origin }.to_json,
+      { endpoint: origin }.to_json,
       FidoMetadata::Client::DEFAULT_HEADERS
     )
 

--- a/spec/conformance/conformance_cache_store.rb
+++ b/spec/conformance/conformance_cache_store.rb
@@ -6,12 +6,6 @@ require "zip"
 
 class ConformanceCacheStore < FidoMetadata::TestCacheStore
   FILENAME = "metadata.zip"
-  attr_reader :origin
-
-  def initialize(origin)
-    super()
-    @origin = origin
-  end
 
   def setup_authenticators
     puts("#{FILENAME} not found, this will affect Metadata Service Test results.") unless File.exist?(FILENAME)
@@ -24,12 +18,12 @@ class ConformanceCacheStore < FidoMetadata::TestCacheStore
     end
   end
 
-  def setup_metadata_store
+  def setup_metadata_store(endpoint)
     puts("Setting up metadata store TOC")
 
     response = Net::HTTP.post(
       URI("https://fidoalliance.co.nz/mds/getEndpoints"),
-      { endpoint: origin }.to_json,
+      { endpoint: endpoint }.to_json,
       FidoMetadata::Client::DEFAULT_HEADERS
     )
 

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -40,20 +40,20 @@ Credential =
 
 host = ENV["HOST"] || "localhost"
 
-
-relying_party = WebAuthn::RelyingParty.new.tap do |rp|
-  rp.origin = "http://#{host}:#{settings.port}"
-  rp.name = RP_NAME
-  rp.algorithms.concat(%w(ES384 ES512 PS384 PS512 RS384 RS512 RS1))
-  rp.silent_authentication = true
-  rp.attestation_root_certificates_finders =
-    MDSFinder.new.tap do |mds|
-      mds.token = ""
-      mds.cache_backend = ConformanceCacheStore.new
-      mds.cache_backend.setup_authenticators
-      mds.cache_backend.setup_metadata_store
-    end
-end
+relying_party =
+  WebAuthn::RelyingParty.new.tap do |rp|
+    rp.origin = "http://#{host}:#{settings.port}"
+    rp.name = RP_NAME
+    rp.algorithms.concat(%w(ES384 ES512 PS384 PS512 RS384 RS512 RS1))
+    rp.silent_authentication = true
+    rp.attestation_root_certificates_finders =
+      MDSFinder.new.tap do |mds|
+        mds.token = ""
+        mds.cache_backend = ConformanceCacheStore.new
+        mds.cache_backend.setup_authenticators
+        mds.cache_backend.setup_metadata_store
+      end
+  end
 
 post "/attestation/options" do
   options = relying_party.options_for_registration(

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -117,18 +117,12 @@ post "/assertion/options" do
 end
 
 post "/assertion/result" do
-<<<<<<< HEAD
   webauthn_credential = WebAuthn::Credential.from_get(params)
 
   user_credential =
     Credential.registered_for(cookies["assertion_username"]).detect do |uc|
       uc.id == webauthn_credential.id
     end
-=======
-  user_credential = Credential.registered_for(cookies["assertion_username"]).detect do |uc|
-    uc.id == params["id"]
-  end
->>>>>>> WIP: Relying Party model
 
   webauthn_credential = relying_party.verify_authentication(
     params,

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -57,7 +57,9 @@ relying_party = WebAuthn::RelyingParty.new(
 
 post "/attestation/options" do
   options = relying_party.options_for_registration(
-    params,
+    attestation: params["attestation"],
+    authenticator_selection: params["authenticatorSelection"],
+    extensions: params["extensions"],
     exclude: Credential.registered_for(params["username"]).map(&:id),
     user: { id: "1", name: params["username"], display_name: params["displayName"] }
   )
@@ -105,7 +107,8 @@ end
 
 post "/assertion/options" do
   options = relying_party.options_for_authentication(
-    params,
+    extensions: params["extensions"],
+    user_verification: params["userVerification"],
     allow: Credential.registered_for(params["username"]).map(&:id)
   )
 

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -42,9 +42,9 @@ host = ENV["HOST"] || "localhost"
 
 mds_finder = MDSFinder.new.tap do |mds|
   mds.token = ""
-  mds.cache_backend = ConformanceCacheStore.new("http://#{host}:#{settings.port}")
+  mds.cache_backend = ConformanceCacheStore.new
   mds.cache_backend.setup_authenticators
-  mds.cache_backend.setup_metadata_store
+  mds.cache_backend.setup_metadata_store("http://#{host}:#{settings.port}")
 end
 
 relying_party = WebAuthn::RelyingParty.new(

--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -40,12 +40,13 @@ Credential =
 
 host = ENV["HOST"] || "localhost"
 
-mds_finder = MDSFinder.new.tap do |mds|
-  mds.token = ""
-  mds.cache_backend = ConformanceCacheStore.new
-  mds.cache_backend.setup_authenticators
-  mds.cache_backend.setup_metadata_store("http://#{host}:#{settings.port}")
-end
+mds_finder =
+  MDSFinder.new.tap do |mds|
+    mds.token = ""
+    mds.cache_backend = ConformanceCacheStore.new
+    mds.cache_backend.setup_authenticators
+    mds.cache_backend.setup_metadata_store("http://#{host}:#{settings.port}")
+  end
 
 relying_party = WebAuthn::RelyingParty.new(
   origin: "http://#{host}:#{settings.port}",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,17 +32,19 @@ def create_credential(
 
   create_result = client.create(rp_id: rp_id)
 
-  attestation_object = if client.encoding
-    relying_party.encoder.decode(create_result["response"]["attestationObject"])
-  else
-    create_result["response"]["attestationObject"]
-  end
+  attestation_object =
+    if client.encoding
+      relying_party.encoder.decode(create_result["response"]["attestationObject"])
+    else
+      create_result["response"]["attestationObject"]
+    end
 
-  client_data_json = if client.encoding
-    relying_party.encoder.decode(create_result["response"]["clientDataJSON"])
-  else
-    create_result["response"]["clientDataJSON"]
-  end
+  client_data_json =
+    if client.encoding
+      relying_party.encoder.decode(create_result["response"]["clientDataJSON"])
+    else
+      create_result["response"]["clientDataJSON"]
+    end
 
   credential_public_key =
     WebAuthn::AuthenticatorAttestationResponse

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       it "doesn't verify" do
         expect {
           attestation_response.verify(original_challenge, origin)
-        }.to raise_exception(WebAuthn::AuthenticatorDataVerificationError)
+        }.to raise_exception(WebAuthn::AttestedCredentialVerificationError)
       end
     end
   end

--- a/spec/webauthn/relying_party_spec.rb
+++ b/spec/webauthn/relying_party_spec.rb
@@ -1,0 +1,329 @@
+require "ostruct"
+require "spec_helper"
+require "webauthn/fake_authenticator"
+require "webauthn/fake_client"
+require "webauthn/relying_party"
+
+RSpec.describe "RelyingParty" do
+  let(:authenticator) { WebAuthn::FakeAuthenticator.new }
+
+  let(:admin_rp) do
+    WebAuthn::RelyingParty.new(
+      origin: "https://admin.example.test",
+      id: 'admin.example.test',
+      name: 'Admin Application'
+    )
+  end
+  let(:admin_fake_client) do
+    WebAuthn::FakeClient.new("https://admin.example.test", authenticator: authenticator)
+  end
+
+  let(:user) do
+    OpenStruct.new(id: WebAuthn.generate_user_id, name: 'John Doe', credentials: [])
+  end
+
+  context "without having any global configuration" do
+    let(:consumer_rp) do
+      WebAuthn::RelyingParty.new(
+        origin: "https://www.example.test",
+        id: 'example.test',
+        name: 'Consumer Application'
+      )
+    end
+    let(:consumer_fake_client) do
+      WebAuthn::FakeClient.new("https://www.example.test", authenticator: authenticator)
+    end
+
+    context "instance two relying parties and use them for the registration ceremony" do
+      it "works when both used for the same user and authenticator" do
+        options = admin_rp.options_for_registration(
+          user: user.to_h.slice(:id, :name),
+          exclude: user.credentials
+        )
+        raw_credential = admin_fake_client.create(challenge: options.challenge, rp_id: admin_rp.id)
+        webauthn_credential = admin_rp.verify_registration(raw_credential, options.challenge)
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential.sign_count).to eq(0)
+
+        options = consumer_rp.options_for_registration(
+          user: user.to_h.slice(:id, :name),
+          exclude: user.credentials
+        )
+        raw_credential = consumer_fake_client.create(challenge: options.challenge, rp_id: consumer_rp.id)
+        webauthn_credential = consumer_rp.verify_registration(raw_credential, options.challenge)
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential.sign_count).to eq(0)
+      end
+
+      it "fails if you pass consumer client data to admin relying party" do
+        options = admin_rp.options_for_registration(
+          user: user.to_h.slice(:id, :name),
+          exclude: user.credentials
+        )
+        raw_credential = consumer_fake_client.create(challenge: options.challenge)
+
+        expect do
+          admin_rp.verify_registration(raw_credential, options.challenge)
+        end.to raise_error(WebAuthn::OriginVerificationError)
+      end
+    end
+
+    context "configuring relying parties and use them for the authentication ceremony" do
+      let(:admin_credential) do
+        create_credential(client: admin_fake_client, relying_party: admin_rp)
+      end
+      let(:consumer_credential) do
+        create_credential(client: consumer_fake_client, relying_party: consumer_rp)
+      end
+
+      before do
+        user.credentials << OpenStruct.new(
+          webauthn_id: admin_credential.first,
+          public_key: admin_rp.encoder.encode(admin_credential.last),
+          sign_count: 0
+        )
+        user.credentials << OpenStruct.new(
+          webauthn_id: consumer_credential.first,
+          public_key: consumer_rp.encoder.encode(consumer_credential.last),
+          sign_count: 0
+        )
+      end
+
+      it "works when both used for the same user and authenticator" do
+        options = admin_rp.options_for_authentication(allow: user.credentials.map(&:webauthn_id))
+
+        raw_credential = admin_fake_client.get(
+          challenge: options.challenge,
+          rp_id: admin_rp.id,
+          sign_count: 1
+        )
+
+        webauthn_credential, stored_credential = admin_rp.verify_authentication(
+          raw_credential,
+          options.challenge
+        ) do |webauthn_credential|
+          user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
+        end
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.sign_count).to eq(1)
+        expect(stored_credential.webauthn_id).to eq(admin_credential.first)
+
+        options = consumer_rp.options_for_authentication(allow: user.credentials.map(&:webauthn_id))
+
+        raw_credential = consumer_fake_client.get(
+          challenge: options.challenge,
+          rp_id: consumer_rp.id,
+          sign_count: 1
+        )
+
+        webauthn_credential, stored_credential = consumer_rp.verify_authentication(
+          raw_credential,
+          options.challenge
+        ) do |webauthn_credential|
+          user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
+        end
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.sign_count).to eq(1)
+        expect(stored_credential.webauthn_id).to eq(consumer_credential.first)
+      end
+
+      it "fails when you try to authenticate a credential registered for consumer in admin" do
+        options = admin_rp.options_for_authentication(allow: user.credentials.map(&:webauthn_id))
+
+        raw_credential = admin_fake_client.get(
+          challenge: options.challenge,
+          rp_id: admin_rp.id,
+          sign_count: 1
+        )
+
+        expect do
+          admin_rp.verify_authentication(
+            raw_credential,
+            options.challenge
+          ) do
+            user.credentials.find { |c| c.webauthn_id == consumer_credential.first }
+          end
+        end.to raise_error(WebAuthn::SignatureVerificationError)
+      end
+    end
+  end
+
+  context "with a global configuration and a different relying party co-existing" do
+    let(:global_configuration_client) do
+      WebAuthn::FakeClient.new(WebAuthn.configuration.origin, authenticator: authenticator)
+    end
+
+    before do
+      WebAuthn.configure do |config|
+        config.origin = "https://www.example.com"
+        config.rp_name = "Example Consumer page"
+      end
+    end
+
+    context "when performing a registragion ceremony" do
+      it "works when both used for the same user and authenticator" do
+        options = admin_rp.options_for_registration(
+          user: user.to_h.slice(:id, :name),
+          exclude: user.credentials
+        )
+        raw_credential = admin_fake_client.create(challenge: options.challenge, rp_id: admin_rp.id)
+        webauthn_credential = admin_rp.verify_registration(raw_credential, options.challenge)
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential.sign_count).to eq(0)
+
+        options = WebAuthn.configuration.relying_party.options_for_registration(
+          user: user.to_h.slice(:id, :name),
+          exclude: user.credentials
+        )
+        raw_credential = global_configuration_client.create(challenge: options.challenge)
+        webauthn_credential = WebAuthn.configuration.relying_party.verify_registration(raw_credential, options.challenge)
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential.sign_count).to eq(0)
+      end
+    end
+
+    context "when performing an authentication ceremony" do
+      let(:admin_credential) do
+        create_credential(client: admin_fake_client, relying_party: admin_rp)
+      end
+      let(:default_configuration_credential) do
+        create_credential(client: global_configuration_client)
+      end
+
+      before do
+        user.credentials << OpenStruct.new(
+          webauthn_id: admin_credential.first,
+          public_key: admin_rp.encoder.encode(admin_credential.last),
+          sign_count: 0
+        )
+        user.credentials << OpenStruct.new(
+          webauthn_id: default_configuration_credential.first,
+          public_key: WebAuthn.configuration.encoder.encode(default_configuration_credential.last),
+          sign_count: 0
+        )
+      end
+
+      it "works when both used for the same user and authenticator" do
+        options = admin_rp.options_for_authentication(allow: user.credentials.map(&:webauthn_id))
+
+        raw_credential = admin_fake_client.get(
+          challenge: options.challenge,
+          rp_id: admin_rp.id,
+          sign_count: 1
+        )
+
+        webauthn_credential, stored_credential = admin_rp.verify_authentication(
+          raw_credential,
+          options.challenge
+        ) do |webauthn_credential|
+          user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
+        end
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.sign_count).to eq(1)
+        expect(stored_credential.webauthn_id).to eq(admin_credential.first)
+
+        options = WebAuthn.configuration.relying_party.options_for_authentication(allow: user.credentials.map(&:webauthn_id))
+
+        raw_credential = global_configuration_client.get(
+          challenge: options.challenge,
+          sign_count: 1
+        )
+
+        webauthn_credential, stored_credential = WebAuthn.configuration.relying_party.verify_authentication(
+          raw_credential,
+          options.challenge
+        ) do |webauthn_credential|
+          user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
+        end
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.sign_count).to eq(1)
+        expect(stored_credential.webauthn_id).to eq(default_configuration_credential.first)
+      end
+    end
+  end
+
+  context "with only a global configuration" do
+    let(:global_configuration_client) do
+      WebAuthn::FakeClient.new(WebAuthn.configuration.origin, authenticator: authenticator)
+    end
+
+    before do
+      WebAuthn.configure do |config|
+        config.origin = "https://www.example.com"
+        config.rp_name = "Example Consumer page"
+      end
+    end
+
+    context "when performing a registragion ceremony" do
+      it "works well when using the former interface" do
+        options = WebAuthn::Credential.options_for_create(
+          user: user.to_h.slice(:id, :name),
+          exclude: user.credentials
+        )
+        raw_credential = global_configuration_client.create(challenge: options.challenge)
+        webauthn_credential = WebAuthn::Credential.from_create(raw_credential)
+        webauthn_credential.verify(options.challenge)
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential.sign_count).to eq(0)
+      end
+    end
+
+    context "when performing an authentication ceremony" do
+      let(:default_configuration_credential) do
+        create_credential(client: global_configuration_client)
+      end
+
+      before do
+        user.credentials << OpenStruct.new(
+          webauthn_id: default_configuration_credential.first,
+          public_key: WebAuthn.configuration.encoder.encode(default_configuration_credential.last),
+          sign_count: 0
+        )
+      end
+
+      it "works well when using the former interface" do
+        options = WebAuthn::Credential.options_for_get(allow: user.credentials.map(&:webauthn_id))
+
+        raw_credential = global_configuration_client.get(
+          challenge: options.challenge,
+          sign_count: 1
+        )
+
+        webauthn_credential = WebAuthn::Credential.from_get(raw_credential)
+        stored_credential = user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
+        webauthn_credential.verify(
+          options.challenge,
+          public_key: stored_credential.public_key,
+          sign_count: stored_credential.sign_count
+        )
+
+        expect(webauthn_credential).to be
+        expect(webauthn_credential.id).to be
+        expect(webauthn_credential.sign_count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/webauthn/relying_party_spec.rb
+++ b/spec/webauthn/relying_party_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ostruct"
 require "spec_helper"
 require "webauthn/fake_authenticator"
@@ -43,9 +45,9 @@ RSpec.describe "RelyingParty" do
         raw_credential = admin_fake_client.create(challenge: options.challenge, rp_id: admin_rp.id)
         webauthn_credential = admin_rp.verify_registration(raw_credential, options.challenge)
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential).to be_truthy
+        expect(webauthn_credential.id).to be_truthy
+        expect(webauthn_credential.public_key).to be_truthy
         expect(webauthn_credential.sign_count).to eq(0)
 
         options = consumer_rp.options_for_registration(
@@ -55,9 +57,9 @@ RSpec.describe "RelyingParty" do
         raw_credential = consumer_fake_client.create(challenge: options.challenge, rp_id: consumer_rp.id)
         webauthn_credential = consumer_rp.verify_registration(raw_credential, options.challenge)
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential).to be_truthy
+        expect(webauthn_credential.id).to be_truthy
+        expect(webauthn_credential.public_key).to be_truthy
         expect(webauthn_credential.sign_count).to eq(0)
       end
 
@@ -104,16 +106,17 @@ RSpec.describe "RelyingParty" do
           sign_count: 1
         )
 
-        webauthn_credential, stored_credential = admin_rp.verify_authentication(
-          raw_credential,
-          options.challenge
-        ) do |webauthn_credential|
+        verified_webauthn_credential, stored_credential =
+          admin_rp.verify_authentication(
+            raw_credential,
+            options.challenge
+          ) do |webauthn_credential|
           user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
         end
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.sign_count).to eq(1)
+        expect(verified_webauthn_credential).to be_truthy
+        expect(verified_webauthn_credential.id).to be_truthy
+        expect(verified_webauthn_credential.sign_count).to eq(1)
         expect(stored_credential.webauthn_id).to eq(admin_credential.first)
 
         options = consumer_rp.options_for_authentication(allow: user.credentials.map(&:webauthn_id))
@@ -124,16 +127,17 @@ RSpec.describe "RelyingParty" do
           sign_count: 1
         )
 
-        webauthn_credential, stored_credential = consumer_rp.verify_authentication(
-          raw_credential,
-          options.challenge
-        ) do |webauthn_credential|
+        verified_webauthn_credential, stored_credential =
+          consumer_rp.verify_authentication(
+            raw_credential,
+            options.challenge
+          ) do |webauthn_credential|
           user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
         end
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.sign_count).to eq(1)
+        expect(verified_webauthn_credential).to be_truthy
+        expect(verified_webauthn_credential.id).to be_truthy
+        expect(verified_webauthn_credential.sign_count).to eq(1)
         expect(stored_credential.webauthn_id).to eq(consumer_credential.first)
       end
 
@@ -179,9 +183,9 @@ RSpec.describe "RelyingParty" do
         raw_credential = admin_fake_client.create(challenge: options.challenge, rp_id: admin_rp.id)
         webauthn_credential = admin_rp.verify_registration(raw_credential, options.challenge)
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential).to be_truthy
+        expect(webauthn_credential.id).to be_truthy
+        expect(webauthn_credential.public_key).to be_truthy
         expect(webauthn_credential.sign_count).to eq(0)
 
         options = WebAuthn.configuration.relying_party.options_for_registration(
@@ -189,11 +193,15 @@ RSpec.describe "RelyingParty" do
           exclude: user.credentials
         )
         raw_credential = global_configuration_client.create(challenge: options.challenge)
-        webauthn_credential = WebAuthn.configuration.relying_party.verify_registration(raw_credential, options.challenge)
+        webauthn_credential =
+          WebAuthn.configuration.relying_party.verify_registration(
+            raw_credential,
+            options.challenge
+          )
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential).to be_truthy
+        expect(webauthn_credential.id).to be_truthy
+        expect(webauthn_credential.public_key).to be_truthy
         expect(webauthn_credential.sign_count).to eq(0)
       end
     end
@@ -228,35 +236,40 @@ RSpec.describe "RelyingParty" do
           sign_count: 1
         )
 
-        webauthn_credential, stored_credential = admin_rp.verify_authentication(
-          raw_credential,
-          options.challenge
-        ) do |webauthn_credential|
+        verified_webauthn_credential, stored_credential =
+          admin_rp.verify_authentication(
+            raw_credential,
+            options.challenge
+          ) do |webauthn_credential|
           user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
         end
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.sign_count).to eq(1)
+        expect(verified_webauthn_credential).to be_truthy
+        expect(verified_webauthn_credential.id).to be_truthy
+        expect(verified_webauthn_credential.sign_count).to eq(1)
         expect(stored_credential.webauthn_id).to eq(admin_credential.first)
 
-        options = WebAuthn.configuration.relying_party.options_for_authentication(allow: user.credentials.map(&:webauthn_id))
+        options =
+          WebAuthn.configuration.relying_party.options_for_authentication(
+            allow: user.credentials.map(&:webauthn_id)
+          )
 
         raw_credential = global_configuration_client.get(
           challenge: options.challenge,
           sign_count: 1
         )
 
-        webauthn_credential, stored_credential = WebAuthn.configuration.relying_party.verify_authentication(
-          raw_credential,
-          options.challenge
-        ) do |webauthn_credential|
+        verified_webauthn_credential, stored_credential =
+          WebAuthn.configuration.relying_party.verify_authentication(
+            raw_credential,
+            options.challenge
+          ) do |webauthn_credential|
           user.credentials.find { |c| c.webauthn_id == webauthn_credential.id }
         end
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.sign_count).to eq(1)
+        expect(verified_webauthn_credential).to be_truthy
+        expect(verified_webauthn_credential.id).to be_truthy
+        expect(verified_webauthn_credential.sign_count).to eq(1)
         expect(stored_credential.webauthn_id).to eq(default_configuration_credential.first)
       end
     end
@@ -284,9 +297,9 @@ RSpec.describe "RelyingParty" do
         webauthn_credential = WebAuthn::Credential.from_create(raw_credential)
         webauthn_credential.verify(options.challenge)
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
-        expect(webauthn_credential.public_key).to be
+        expect(webauthn_credential).to be_truthy
+        expect(webauthn_credential.id).to be_truthy
+        expect(webauthn_credential.public_key).to be_truthy
         expect(webauthn_credential.sign_count).to eq(0)
       end
     end
@@ -320,8 +333,8 @@ RSpec.describe "RelyingParty" do
           sign_count: stored_credential.sign_count
         )
 
-        expect(webauthn_credential).to be
-        expect(webauthn_credential.id).to be
+        expect(webauthn_credential).to be_truthy
+        expect(webauthn_credential.id).to be_truthy
         expect(webauthn_credential.sign_count).to eq(1)
       end
     end


### PR DESCRIPTION
Create a new `RelyingParty` class to allow the user of the gem to set up multiple instances (tries to solve https://github.com/cedarcode/webauthn-ruby/issues/285). 
This class also makes the registration/authentication ceremonies simpler.