### PR TITLE
refactor: Attestation concept encapsulation

### DIFF
--- a/lib/webauthn/attestation.rb
+++ b/lib/webauthn/attestation.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "cbor"
+require "openssl"
+require "webauthn/attestation_statement"
+require "webauthn/authenticator_data"
+
+module WebAuthn
+  class Attestation
+    def self.deserialize(attestation_object)
+      from_map(CBOR.decode(attestation_object))
+    end
+
+    def self.from_map(map)
+      new(
+        authenticator_data: WebAuthn::AuthenticatorData.new(map["authData"]),
+        attestation_statement: WebAuthn::AttestationStatement.from(map["fmt"], map["attStmt"])
+      )
+    end
+
+    attr_reader :authenticator_data, :attestation_statement
+
+    def initialize(authenticator_data:, attestation_statement:)
+      @authenticator_data = authenticator_data
+      @attestation_statement = attestation_statement
+    end
+
+    def valid_attested_credential?
+      authenticator_data.attested_credential_data_included? &&
+        authenticator_data.attested_credential_data.valid?
+    end
+
+    def valid_attestation_statement?(client_data_hash)
+      @type, @trust_path = attestation_statement.valid?(authenticator_data, client_data_hash)
+    end
+
+    def trustworthy?
+      case type
+      when WebAuthn::AttestationStatement::ATTESTATION_TYPE_NONE
+        acceptable_types.include?('None')
+      when WebAuthn::AttestationStatement::ATTESTATION_TYPE_SELF
+        acceptable_types.include?('Self')
+      else
+        acceptable_types.include?(type) && root_store.verify(subject_certificate, intermediate_certificates)
+      end
+    end
+
+    def aaguid
+      raw_aaguid = authenticator_data.attested_credential_data.raw_aaguid
+
+      unless raw_aaguid == WebAuthn::AuthenticatorData::AttestedCredentialData::ZEROED_AAGUID
+        authenticator_data.attested_credential_data.aaguid
+      end
+    end
+
+    def certificate_key
+      raw_subject_key_identifier(attestation_statement.attestation_certificate)&.unpack("H*")&.[](0)
+    end
+
+    private
+
+    attr_reader :type, :trust_path
+
+    def acceptable_types
+      configuration.acceptable_attestation_types
+    end
+
+    def subject_certificate
+      trust_path[0]
+    end
+
+    def intermediate_certificates
+      trust_path[1..-1]
+    end
+
+    def root_store
+      @root_store ||=
+        OpenSSL::X509::Store.new.tap do |store|
+          root_certificates.each do |certificate|
+            store.add_cert(certificate)
+          end
+        end
+    end
+
+    def root_certificates
+      configuration.attestation_root_certificates_finders.reduce([]) do |certs, finder|
+        if certs.empty?
+          finder.find(
+            attestation_format: attestation_statement.format,
+            aaguid: aaguid,
+            attestation_certificate_key_id: certificate_key
+          ) || []
+        else
+          certs
+        end
+      end
+    end
+
+    def raw_subject_key_identifier(certificate)
+      extension = certificate.extensions.detect { |ext| ext.oid == "subjectKeyIdentifier" }
+      return unless extension
+
+      ext_asn1 = OpenSSL::ASN1.decode(extension.to_der)
+      ext_value = ext_asn1.value.last
+      OpenSSL::ASN1.decode(ext_value.value).value
+    end
+
+    def configuration
+      WebAuthn.configuration
+    end
+  end
+end

--- a/lib/webauthn/attestation.rb
+++ b/lib/webauthn/attestation.rb
@@ -49,8 +49,8 @@ module WebAuthn
       authenticator_data.aaguid
     end
 
-    def certificate_key
-      attestation_statement.certificate_key
+    def certificate_key_id
+      attestation_statement.certificate_key_id
     end
 
     private
@@ -84,7 +84,7 @@ module WebAuthn
           finder.find(
             attestation_format: attestation_statement.format,
             aaguid: aaguid,
-            attestation_certificate_key_id: certificate_key
+            attestation_certificate_key_id: certificate_key_id
           ) || []
         else
           certs

--- a/lib/webauthn/attestation.rb
+++ b/lib/webauthn/attestation.rb
@@ -46,15 +46,11 @@ module WebAuthn
     end
 
     def aaguid
-      raw_aaguid = authenticator_data.attested_credential_data.raw_aaguid
-
-      unless raw_aaguid == WebAuthn::AuthenticatorData::AttestedCredentialData::ZEROED_AAGUID
-        authenticator_data.attested_credential_data.aaguid
-      end
+      authenticator_data.aaguid
     end
 
     def certificate_key
-      raw_subject_key_identifier(attestation_statement.attestation_certificate)&.unpack("H*")&.[](0)
+      attestation_statement.certificate_key
     end
 
     private
@@ -94,15 +90,6 @@ module WebAuthn
           certs
         end
       end
-    end
-
-    def raw_subject_key_identifier(certificate)
-      extension = certificate.extensions.detect { |ext| ext.oid == "subjectKeyIdentifier" }
-      return unless extension
-
-      ext_asn1 = OpenSSL::ASN1.decode(extension.to_der)
-      ext_value = ext_asn1.value.last
-      OpenSSL::ASN1.decode(ext_value.value).value
     end
 
     def configuration

--- a/lib/webauthn/attestation_statement/android_key.rb
+++ b/lib/webauthn/attestation_statement/android_key.rb
@@ -18,6 +18,10 @@ module WebAuthn
           [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC, attestation_trust_path]
       end
 
+      def format
+        ATTESTATION_FORMAT_ANDROID_KEY
+      end
+
       private
 
       def valid_signature?(authenticator_data, client_data_hash)

--- a/lib/webauthn/attestation_statement/android_safetynet.rb
+++ b/lib/webauthn/attestation_statement/android_safetynet.rb
@@ -15,6 +15,10 @@ module WebAuthn
           [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC, attestation_trust_path]
       end
 
+      def format
+        ATTESTATION_FORMAT_ANDROID_SAFETYNET
+      end
+
       def attestation_certificate
         attestation_trust_path.first
       end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -40,6 +40,10 @@ module WebAuthn
         end
       end
 
+      def certificate_key
+        raw_subject_key_identifier&.unpack("H*")&.[](0)
+      end
+
       private
 
       attr_reader :statement
@@ -83,6 +87,15 @@ module WebAuthn
         if certificates&.any?
           certificates
         end
+      end
+
+      def raw_subject_key_identifier
+        extension = attestation_certificate.extensions.detect { |ext| ext.oid == "subjectKeyIdentifier" }
+        return unless extension
+
+        ext_asn1 = OpenSSL::ASN1.decode(extension.to_der)
+        ext_value = ext_asn1.value.last
+        OpenSSL::ASN1.decode(ext_value.value).value
       end
     end
   end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -26,6 +26,10 @@ module WebAuthn
         raise NotImplementedError
       end
 
+      def format
+        raise NotImplementedError
+      end
+
       def attestation_certificate
         certificates&.first
       end

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -40,7 +40,7 @@ module WebAuthn
         end
       end
 
-      def certificate_key
+      def certificate_key_id
         raw_subject_key_identifier&.unpack("H*")&.[](0)
       end
 

--- a/lib/webauthn/attestation_statement/fido_u2f.rb
+++ b/lib/webauthn/attestation_statement/fido_u2f.rb
@@ -22,6 +22,10 @@ module WebAuthn
           [WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC_OR_ATTCA, attestation_trust_path]
       end
 
+      def format
+        ATTESTATION_FORMAT_FIDO_U2F
+      end
+
       private
 
       def valid_format?

--- a/lib/webauthn/attestation_statement/none.rb
+++ b/lib/webauthn/attestation_statement/none.rb
@@ -12,6 +12,10 @@ module WebAuthn
           false
         end
       end
+
+      def format
+        ATTESTATION_FORMAT_NONE
+      end
     end
   end
 end

--- a/lib/webauthn/attestation_statement/packed.rb
+++ b/lib/webauthn/attestation_statement/packed.rb
@@ -23,6 +23,10 @@ module WebAuthn
           attestation_type_and_trust_path
       end
 
+      def format
+        ATTESTATION_FORMAT_PACKED
+      end
+
       private
 
       def valid_algorithm?(credential)

--- a/lib/webauthn/attestation_statement/tpm.rb
+++ b/lib/webauthn/attestation_statement/tpm.rb
@@ -43,6 +43,10 @@ module WebAuthn
         end
       end
 
+      def format
+        ATTESTATION_FORMAT_TPM
+      end
+
       private
 
       def valid_signature?

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -68,9 +68,11 @@ module WebAuthn
       attestation.aaguid
     end
 
-    def attestation_certificate_key
-      attestation.certificate_key
+    def attestation_certificate_key_id
+      attestation.certificate_key_id
     end
+
+    alias_method :attestation_certificate_key, :attestation_certificate_key_id
 
     private
 

--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -4,9 +4,8 @@ require "cbor"
 require "uri"
 require "openssl"
 
-require "webauthn/authenticator_data"
+require "webauthn/attestation"
 require "webauthn/authenticator_response"
-require "webauthn/attestation_statement"
 require "webauthn/client_data"
 require "webauthn/encoder"
 
@@ -50,31 +49,27 @@ module WebAuthn
     end
 
     def attestation_statement
-      @attestation_statement ||=
-        WebAuthn::AttestationStatement.from(attestation["fmt"], attestation["attStmt"])
+      attestation.attestation_statement
     end
 
     def authenticator_data
-      @authenticator_data ||= WebAuthn::AuthenticatorData.new(attestation["authData"])
+      attestation.authenticator_data
     end
 
     def attestation_format
-      attestation["fmt"]
+      attestation.attestation_format
     end
 
     def attestation
-      @attestation ||= CBOR.decode(attestation_object)
+      @attestation ||= WebAuthn::Attestation.deserialize(attestation_object)
     end
 
     def aaguid
-      raw_aaguid = authenticator_data.attested_credential_data.raw_aaguid
-      unless raw_aaguid == WebAuthn::AuthenticatorData::AttestedCredentialData::ZEROED_AAGUID
-        authenticator_data.attested_credential_data.aaguid
-      end
+      attestation.aaguid
     end
 
     def attestation_certificate_key
-      raw_subject_key_identifier(attestation_statement.attestation_certificate)&.unpack("H*")&.[](0)
+      attestation.certificate_key
     end
 
     private
@@ -86,62 +81,15 @@ module WebAuthn
     end
 
     def valid_attested_credential?
-      authenticator_data.attested_credential_data_included? &&
-        authenticator_data.attested_credential_data.valid?
+      attestation.valid_attested_credential?
     end
 
     def valid_attestation_statement?
-      @attestation_type, @attestation_trust_path = attestation_statement.valid?(authenticator_data, client_data.hash)
+      @attestation_type, @attestation_trust_path = attestation.valid_attestation_statement?(client_data.hash)
     end
 
     def valid_attestation_trustworthiness?
-      case @attestation_type
-      when WebAuthn::AttestationStatement::ATTESTATION_TYPE_NONE
-        WebAuthn.configuration.acceptable_attestation_types.include?('None')
-      when WebAuthn::AttestationStatement::ATTESTATION_TYPE_SELF
-        WebAuthn.configuration.acceptable_attestation_types.include?('Self')
-      else
-        WebAuthn.configuration.acceptable_attestation_types.include?(@attestation_type) &&
-          attestation_root_certificates_store.verify(leaf_certificate, signing_certificates)
-      end
-    end
-
-    def raw_subject_key_identifier(certificate)
-      extension = certificate.extensions.detect { |ext| ext.oid == "subjectKeyIdentifier" }
-      return unless extension
-
-      ext_asn1 = OpenSSL::ASN1.decode(extension.to_der)
-      ext_value = ext_asn1.value.last
-      OpenSSL::ASN1.decode(ext_value.value).value
-    end
-
-    def attestation_root_certificates_store
-      certificates =
-        WebAuthn.configuration.attestation_root_certificates_finders.reduce([]) do |certs, finder|
-          if certs.empty?
-            finder.find(
-              attestation_format: attestation_format,
-              aaguid: aaguid,
-              attestation_certificate_key_id: attestation_certificate_key
-            ) || []
-          else
-            certs
-          end
-        end
-
-      OpenSSL::X509::Store.new.tap do |store|
-        certificates.each do |cert|
-          store.add_cert(cert)
-        end
-      end
-    end
-
-    def signing_certificates
-      @attestation_trust_path[1..-1]
-    end
-
-    def leaf_certificate
-      @attestation_trust_path.first
+      attestation.trustworthy?
     end
   end
 end

--- a/lib/webauthn/authenticator_data.rb
+++ b/lib/webauthn/authenticator_data.rb
@@ -79,6 +79,14 @@ module WebAuthn
       @flags ||= data_at(flags_position, FLAGS_LENGTH).unpack("b*")[0]
     end
 
+    def aaguid
+      raw_aaguid = attested_credential_data.raw_aaguid
+
+      unless raw_aaguid == WebAuthn::AuthenticatorData::AttestedCredentialData::ZEROED_AAGUID
+        attested_credential_data.aaguid
+      end
+    end
+
     private
 
     def valid_length?

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "returns the attestation certificate key" do
-      expect(attestation_response.attestation_certificate_key).to(
+      expect(attestation_response.attestation_certificate_key_id).to(
         eq("f4b64a68c334e901b8e23c6e66e6866c31931f5d")
       )
     end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -502,7 +502,8 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
-      attestation_response.attestation["attStmt"]["sig"] = "corrupted signature".b
+      attestation_response.attestation.attestation_statement.instance_variable_get(:@statement)["sig"] =
+        "corrupted signature".b
     end
 
     context "when verification is set to true" do


### PR DESCRIPTION
Split the `AuthenticatorAttestationResponse` into `AuthenticatorAttestationResponse` and `Attestation` in an attempt to provide easier maintainability and making it easier to reason about new features involving "attestation", by better encapsulating different concepts in different objects. 