### PR TITLE
fix: AttestationStatement::TPM#valid? blowing up when using libssl 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 dist: bionic
 language: ruby
-cache: bundler
 
-rvm:
-  - ruby-head
-  - 2.7.1
-  - 2.6.6
-  - 2.5.8
-  - 2.4.10
+cache:
+  bundler: true
+  directories:
+    - /home/travis/.rvm/
+
+env:
+  - LIBSSL=1.1 RB=2.7.1
+  - LIBSSL=1.1 RB=2.6.6
+  - LIBSSL=1.1 RB=2.5.8
+  - LIBSSL=1.1 RB=2.4.10
+  - LIBSSL=1.1 RB=ruby-head
+  - LIBSSL=1.0 RB=2.7.1
+  - LIBSSL=1.0 RB=2.6.6
+  - LIBSSL=1.0 RB=2.5.8
+  - LIBSSL=1.0 RB=2.4.10
+  - LIBSSL=1.0 RB=ruby-head
 
 gemfile:
   - gemfiles/cose_head.gemfile
@@ -19,9 +28,12 @@ gemfile:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: ruby-head
+    - env: LIBSSL=1.1 RB=ruby-head
+    - env: LIBSSL=1.0 RB=ruby-head
     - gemfile: gemfiles/cose_head.gemfile
     - gemfile: gemfiles/openssl_head.gemfile
 
 before_install:
+  - ./script/ci/install-openssl
+  - ./script/ci/install-ruby
   - gem install bundler -v "~> 2.0"

--- a/script/ci/install-openssl
+++ b/script/ci/install-openssl
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$LIBSSL" == "1.0" ]]; then
+  sudo apt-get install libssl1.0-dev
+fi

--- a/script/ci/install-ruby
+++ b/script/ci/install-ruby
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+source "$HOME/.rvm/scripts/rvm"
+
+if [[ "$LIBSSL" == "1.0" ]]; then
+  rvm use --install $RB --autolibs=read-only --disable-binary
+elif [[ "$LIBSSL" == "1.1" ]]; then
+  rvm use --install $RB --binary --fuzzy
+fi
+
+[[ "`ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'`" =~ "OpenSSL $LIBSSL" ]] || { echo "Wrong libssl version"; exit 1; }

--- a/spec/conformance/Gemfile.lock
+++ b/spec/conformance/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       openssl (~> 2.0)
       safety_net_attestation (~> 0.4.0)
       securecompare (~> 1.0)
-      tpm-key_attestation (~> 0.8.0)
+      tpm-key_attestation (~> 0.9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -55,7 +55,7 @@ GEM
       sinatra (= 2.0.8.1)
       tilt (~> 2.0)
     tilt (2.0.10)
-    tpm-key_attestation (0.8.0)
+    tpm-key_attestation (0.9.0)
       bindata (~> 2.4)
       openssl-signature_algorithm (~> 0.4.0)
 
@@ -75,4 +75,4 @@ RUBY VERSION
    ruby 2.7.0p-1
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "openssl", "~> 2.0"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
   spec.add_dependency "securecompare", "~> 1.0"
-  spec.add_dependency "tpm-key_attestation", "~> 0.8.0"
+  spec.add_dependency "tpm-key_attestation", "~> 0.9.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"


### PR DESCRIPTION
## What

`AttestationStatement::TPM#valid?` is blowing up when using libssl v1.0.2.
The error was inside [TPM Key Attestation](https://github.com/cedarcode/tpm-key_attestation) – see https://github.com/cedarcode/tpm-key_attestation/pull/5 – so we must update that dependency.

## Steps Taken

- [x] - Write tests for reproducing bugs
- [x] - Fix bug by updating the tpm-key_attestation gem

## References

- https://github.com/cedarcode/tpm-key_attestation/pull/5
- https://github.com/cedarcode/tpm-key_attestation/pull/6
- https://github.com/cedarcode/openssl-signature_algorithm/pull/1