### PR TITLE
Remove ECDAA

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,7 @@ credential_with_assertion.verify(
 | -------- | :--------: |
 | packed (self attestation) | Yes |
 | packed (x5c attestation) | Yes |
-| packed (ECDAA attestation) | No |
 | tpm (x5c attestation) | Yes |
-| tpm (ECDAA attestation) | No |
 | android-key | Yes |
 | android-safetynet | Yes |
 | fido-u2f | Yes |

--- a/lib/webauthn/attestation_statement/base.rb
+++ b/lib/webauthn/attestation_statement/base.rb
@@ -10,7 +10,6 @@ module WebAuthn
     ATTESTATION_TYPE_BASIC = "Basic"
     ATTESTATION_TYPE_SELF = "Self"
     ATTESTATION_TYPE_ATTCA = "AttCA"
-    ATTESTATION_TYPE_ECDAA = "ECDAA"
     ATTESTATION_TYPE_BASIC_OR_ATTCA = "Basic_or_AttCA"
 
     ATTESTATION_TYPES_WITH_ROOT = [
@@ -79,10 +78,6 @@ module WebAuthn
 
       def raw_certificates
         statement["x5c"]
-      end
-
-      def raw_ecdaa_key_id
-        statement["ecdaaKeyId"]
       end
 
       def signature

--- a/lib/webauthn/attestation_statement/packed.rb
+++ b/lib/webauthn/attestation_statement/packed.rb
@@ -6,13 +6,10 @@ require "webauthn/signature_verifier"
 
 module WebAuthn
   # Implements https://www.w3.org/TR/2018/CR-webauthn-20180807/#packed-attestation
-  # ECDAA attestation is unsupported.
   module AttestationStatement
     class Packed < Base
       # Follows "Verification procedure"
       def valid?(authenticator_data, client_data_hash)
-        check_unsupported_feature
-
         valid_format? &&
           valid_algorithm?(authenticator_data.credential) &&
           valid_ec_public_keys?(authenticator_data.credential) &&
@@ -30,19 +27,11 @@ module WebAuthn
       end
 
       def self_attestation?
-        !raw_certificates && !raw_ecdaa_key_id
+        !raw_certificates
       end
 
       def valid_format?
-        algorithm && signature && (
-          [raw_certificates, raw_ecdaa_key_id].compact.size < 2
-        )
-      end
-
-      def check_unsupported_feature
-        if raw_ecdaa_key_id
-          raise NotSupportedError, "ecdaaKeyId of the packed attestation format is not implemented yet"
-        end
+        algorithm && signature
       end
 
       def valid_ec_public_keys?(credential)

--- a/lib/webauthn/attestation_statement/tpm.rb
+++ b/lib/webauthn/attestation_statement/tpm.rb
@@ -19,23 +19,16 @@ module WebAuthn
       }.freeze
 
       def valid?(authenticator_data, client_data_hash)
-        case attestation_type
-        when ATTESTATION_TYPE_ATTCA
+        attestation_type == ATTESTATION_TYPE_ATTCA &&
           ver == TPM_V2 &&
-            valid_key_attestation?(
-              authenticator_data.data + client_data_hash,
-              authenticator_data.credential.public_key_object,
-              authenticator_data.aaguid
-            ) &&
-            matching_aaguid?(authenticator_data.attested_credential_data.raw_aaguid) &&
-            trustworthy?(aaguid: authenticator_data.aaguid) &&
-            [attestation_type, attestation_trust_path]
-        when ATTESTATION_TYPE_ECDAA
-          raise(
-            WebAuthn::AttestationStatement::Base::NotSupportedError,
-            "Attestation type ECDAA is not supported"
-          )
-        end
+          valid_key_attestation?(
+            authenticator_data.data + client_data_hash,
+            authenticator_data.credential.public_key_object,
+            authenticator_data.aaguid
+          ) &&
+          matching_aaguid?(authenticator_data.attested_credential_data.raw_aaguid) &&
+          trustworthy?(aaguid: authenticator_data.aaguid) &&
+          [attestation_type, attestation_trust_path]
       end
 
       private
@@ -78,10 +71,8 @@ module WebAuthn
       end
 
       def attestation_type
-        if raw_certificates && !raw_ecdaa_key_id
+        if raw_certificates
           ATTESTATION_TYPE_ATTCA
-        elsif raw_ecdaa_key_id && !raw_certificates
-          ATTESTATION_TYPE_ECDAA
         else
           raise "Attestation type invalid"
         end

--- a/spec/webauthn/attestation_statement/packed_spec.rb
+++ b/spec/webauthn/attestation_statement/packed_spec.rb
@@ -269,20 +269,5 @@ RSpec.describe "Packed attestation" do
         end
       end
     end
-
-    context "ECDAA" do
-      let(:statement) do
-        WebAuthn::AttestationStatement::Packed.new("alg" => -260, "sig" => "signature".b, "ecdaaKeyId" => "key-id".b)
-      end
-
-      it "tells the user it's not yet supported" do
-        expect {
-          statement.valid?(authenticator_data, client_data_hash)
-        }.to raise_error(
-          WebAuthn::AttestationStatement::Base::NotSupportedError,
-          "ecdaaKeyId of the packed attestation format is not implemented yet"
-        )
-      end
-    end
   end
 end

--- a/spec/webauthn/attestation_statement/tpm_spec.rb
+++ b/spec/webauthn/attestation_statement/tpm_spec.rb
@@ -454,28 +454,6 @@ RSpec.describe "TPM attestation statement" do
       end
     end
 
-    context "ECDAA attestation" do
-      let(:statement) do
-        WebAuthn::AttestationStatement::TPM.new(
-          "ver" => "2.0",
-          "alg" => -260,
-          "ecdaaKeyId" => "ecdaa-key-id",
-          "sig" => "sig",
-          "certInfo" => "cert-info",
-          "pubArea" => "pub-area"
-        )
-      end
-
-      it "tells the user it's not yet supported" do
-        expect {
-          statement.valid?("authenticator-data", "client-data-hash")
-        }.to raise_error(
-          WebAuthn::AttestationStatement::Base::NotSupportedError,
-          "Attestation type ECDAA is not supported"
-        )
-      end
-    end
-
     context "when attestation type is not specified" do
       let(:statement) do
         WebAuthn::AttestationStatement::TPM.new(


### PR DESCRIPTION
It's being removed from WebAuthn level 2 as it was never implemented by browser vendors or authenticator manufacturers, see https://github.com/w3c/webauthn/issues/1410