### PR TITLE
test: fix flaky tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,7 +108,7 @@ def create_root_certificate(key)
   certificate.subject = OpenSSL::X509::Name.new([["CN", common_name]])
   certificate.issuer = certificate.subject
   certificate.public_key = root_key
-  certificate.not_before = Time.now
+  certificate.not_before = Time.now - 1
   certificate.not_after = Time.now + 60
 
   extension_factory = OpenSSL::X509::ExtensionFactory.new
@@ -131,7 +131,7 @@ def issue_certificate(ca_certificate, ca_key, key, name: nil)
 
   certificate.subject = OpenSSL::X509::Name.new([["CN", common_name]])
   certificate.issuer = ca_certificate.subject
-  certificate.not_before = Time.now
+  certificate.not_before = Time.now - 1
   certificate.not_after = Time.now + 60
   certificate.public_key = key
 

--- a/spec/webauthn/attestation_statement/android_key_spec.rb
+++ b/spec/webauthn/attestation_statement/android_key_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "AndroidKey attestation" do
       certificate = OpenSSL::X509::Certificate.new
       certificate.subject = OpenSSL::X509::Name.new([["CN", "Fake Attestation"]])
       certificate.issuer = root_certificate.subject
-      certificate.not_before = Time.now
+      certificate.not_before = Time.now - 1
       certificate.not_after = Time.now + 60
       certificate.public_key = attestation_key
 

--- a/spec/webauthn/attestation_statement/packed_spec.rb
+++ b/spec/webauthn/attestation_statement/packed_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Packed attestation" do
       let(:attestation_certificate_version) { 2 }
       let(:attestation_certificate_subject) { "/C=UY/O=ACME/OU=Authenticator Attestation/CN=CN" }
       let(:attestation_certificate_basic_constraints) { "CA:FALSE" }
-      let(:attestation_certificate_start_time) { Time.now }
+      let(:attestation_certificate_start_time) { Time.now - 1 }
       let(:attestation_certificate_end_time) { Time.now + 60 }
 
       let(:attestation_certificate) do
@@ -119,7 +119,7 @@ RSpec.describe "Packed attestation" do
       end
 
       let(:root_key) { OpenSSL::PKey::EC.new("prime256v1").generate_key }
-      let(:root_certificate_start_time) { Time.now }
+      let(:root_certificate_start_time) { Time.now - 1 }
       let(:root_certificate_end_time) { Time.now + 60 }
 
       let(:root_certificate) do
@@ -230,7 +230,7 @@ RSpec.describe "Packed attestation" do
         end
 
         context "because it has expired" do
-          let(:attestation_certificate_end_time) { Time.now }
+          let(:attestation_certificate_end_time) { Time.now - 1 }
 
           it "fails" do
             expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
@@ -248,7 +248,7 @@ RSpec.describe "Packed attestation" do
         end
 
         context "because a cert has expired" do
-          let(:root_certificate_end_time) { Time.now }
+          let(:root_certificate_end_time) { Time.now - 1 }
 
           it "fails" do
             expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy

--- a/spec/webauthn/attestation_statement/tpm_spec.rb
+++ b/spec/webauthn/attestation_statement/tpm_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "TPM attestation statement" do
           str=UTF8:"#{aik_certificate_san_version}"
         OPENSSL_CONF
       end
-      let(:aik_certificate_start_time) { Time.now }
+      let(:aik_certificate_start_time) { Time.now - 1 }
       let(:aik_certificate_end_time) { Time.now + 60 }
       let(:root_key) { OpenSSL::PKey::RSA.new(2048) }
       let(:root_certificate) { create_root_certificate(root_key) }
@@ -411,7 +411,7 @@ RSpec.describe "TPM attestation statement" do
         end
 
         context "because it has expired" do
-          let(:aik_certificate_end_time) { Time.now }
+          let(:aik_certificate_end_time) { Time.now - 1 }
 
           it "returns false" do
             expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy


### PR DESCRIPTION
Don't try to test certificate invalidation so close to the timestamp
limit. Not worth it and unreliable.

Inspired by https://github.com/cedarcode/tpm-key_attestation/pull/10.