### PR TITLE
feat: add API methods for providing received extension information

### DIFF
--- a/lib/webauthn/fake_authenticator.rb
+++ b/lib/webauthn/fake_authenticator.rb
@@ -18,7 +18,8 @@ module WebAuthn
       user_present: true,
       user_verified: false,
       attested_credential_data: true,
-      sign_count: nil
+      sign_count: nil,
+      extensions: nil
     )
       credential_id, credential_key, credential_sign_count = new_credential
       sign_count ||= credential_sign_count
@@ -37,7 +38,8 @@ module WebAuthn
         user_present: user_present,
         user_verified: user_verified,
         attested_credential_data: attested_credential_data,
-        sign_count: sign_count
+        sign_count: sign_count,
+        extensions: extensions
       ).serialize
     end
 
@@ -47,7 +49,8 @@ module WebAuthn
       user_present: true,
       user_verified: false,
       aaguid: AuthenticatorData::AAGUID,
-      sign_count: nil
+      sign_count: nil,
+      extensions: nil
     )
       credential_options = credentials[rp_id]
 
@@ -63,6 +66,7 @@ module WebAuthn
           aaguid: aaguid,
           credential: nil,
           sign_count: sign_count || credential_sign_count,
+          extensions: extensions
         ).serialize
 
         signature = credential_key.sign("SHA256", authenticator_data + client_data_hash)

--- a/lib/webauthn/fake_authenticator/attestation_object.rb
+++ b/lib/webauthn/fake_authenticator/attestation_object.rb
@@ -14,7 +14,8 @@ module WebAuthn
         user_present: true,
         user_verified: false,
         attested_credential_data: true,
-        sign_count: 0
+        sign_count: 0,
+        extensions: nil
       )
         @client_data_hash = client_data_hash
         @rp_id_hash = rp_id_hash
@@ -24,6 +25,7 @@ module WebAuthn
         @user_verified = user_verified
         @attested_credential_data = attested_credential_data
         @sign_count = sign_count
+        @extensions = extensions
       end
 
       def serialize
@@ -44,7 +46,8 @@ module WebAuthn
         :user_present,
         :user_verified,
         :attested_credential_data,
-        :sign_count
+        :sign_count,
+        :extensions
       )
 
       def authenticator_data
@@ -60,7 +63,8 @@ module WebAuthn
               credential: credential_data,
               user_present: user_present,
               user_verified: user_verified,
-              sign_count: 0
+              sign_count: 0,
+              extensions: extensions
             )
           end
       end

--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -29,7 +29,8 @@ module WebAuthn
       rp_id: nil,
       user_present: true,
       user_verified: false,
-      attested_credential_data: true
+      attested_credential_data: true,
+      extensions: nil
     )
       rp_id ||= URI.parse(origin).host
 
@@ -41,7 +42,8 @@ module WebAuthn
         client_data_hash: client_data_hash,
         user_present: user_present,
         user_verified: user_verified,
-        attested_credential_data: attested_credential_data
+        attested_credential_data: attested_credential_data,
+        extensions: extensions
       )
 
       id =
@@ -58,6 +60,7 @@ module WebAuthn
         "type" => "public-key",
         "id" => internal_encoder.encode(id),
         "rawId" => encoder.encode(id),
+        "clientExtensionResults" => extensions,
         "response" => {
           "attestationObject" => encoder.encode(attestation_object),
           "clientDataJSON" => encoder.encode(client_data_json)
@@ -65,7 +68,12 @@ module WebAuthn
       }
     end
 
-    def get(challenge: fake_challenge, rp_id: nil, user_present: true, user_verified: false, sign_count: nil)
+    def get(challenge: fake_challenge,
+            rp_id: nil,
+            user_present: true,
+            user_verified: false,
+            sign_count: nil,
+            extensions: nil)
       rp_id ||= URI.parse(origin).host
 
       client_data_json = data_json_for(:get, encoder.decode(challenge))
@@ -77,12 +85,14 @@ module WebAuthn
         user_present: user_present,
         user_verified: user_verified,
         sign_count: sign_count,
+        extensions: extensions
       )
 
       {
         "type" => "public-key",
         "id" => internal_encoder.encode(assertion[:credential_id]),
         "rawId" => encoder.encode(assertion[:credential_id]),
+        "clientExtensionResults" => extensions,
         "response" => {
           "clientDataJSON" => encoder.encode(client_data_json),
           "authenticatorData" => encoder.encode(assertion[:authenticator_data]),

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -32,7 +32,11 @@ module WebAuthn
     end
 
     def sign_count
-      response&.authenticator_data&.sign_count
+      authenticator_data&.sign_count
+    end
+
+    def authenticator_extension_outputs
+      authenticator_data.extension_data if authenticator_data&.extension_data_included?
     end
 
     private
@@ -43,6 +47,10 @@ module WebAuthn
 
     def valid_id?
       raw_id && id && raw_id == WebAuthn.standard_encoder.decode(id)
+    end
+
+    def authenticator_data
+      response&.authenticator_data
     end
 
     def encoder

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -4,21 +4,23 @@ require "webauthn/encoder"
 
 module WebAuthn
   class PublicKeyCredential
-    attr_reader :type, :id, :raw_id, :response
+    attr_reader :type, :id, :raw_id, :client_extension_outputs, :response
 
     def self.from_client(credential)
       new(
         type: credential["type"],
         id: credential["id"],
         raw_id: WebAuthn.configuration.encoder.decode(credential["rawId"]),
+        client_extension_outputs: credential["clientExtensionResults"],
         response: response_class.from_client(credential["response"])
       )
     end
 
-    def initialize(type:, id:, raw_id:, response:)
+    def initialize(type:, id:, raw_id:, client_extension_outputs: {}, response:)
       @type = type
       @id = id
       @raw_id = raw_id
+      @client_extension_outputs = client_extension_outputs
       @response = response
     end
 

--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -93,21 +93,41 @@ RSpec.describe "PublicKeyCredential" do
       end
     end
 
-    context "when clientExtensionResults is received" do
-      let(:public_key_credential) do
-        WebAuthn::PublicKeyCredentialWithAttestation.new(
-          type: type,
-          id: id,
-          raw_id: raw_id,
-          client_extension_outputs: { "appid" => "true" },
-          response: attestation_response
-        )
+    context "when clientExtensionResults" do
+      context "are not received" do
+        let(:public_key_credential) do
+          WebAuthn::PublicKeyCredentialWithAttestation.new(
+            type: type,
+            id: id,
+            raw_id: raw_id,
+            client_extension_outputs: nil,
+            response: attestation_response
+          )
+        end
+
+        it "works" do
+          expect(public_key_credential.verify(challenge)).to be_truthy
+
+          expect(public_key_credential.client_extension_outputs).to be_nil
+        end
       end
 
-      it "works" do
-        expect(public_key_credential.verify(challenge)).to be_truthy
+      context "are received" do
+        let(:public_key_credential) do
+          WebAuthn::PublicKeyCredentialWithAttestation.new(
+            type: type,
+            id: id,
+            raw_id: raw_id,
+            client_extension_outputs: { "appid" => "true" },
+            response: attestation_response
+          )
+        end
 
-        expect(public_key_credential.client_extension_outputs).to eq({ "appid" => "true" })
+        it "works" do
+          expect(public_key_credential.verify(challenge)).to be_truthy
+
+          expect(public_key_credential.client_extension_outputs).to eq({ "appid" => "true" })
+        end
       end
     end
 

--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -114,11 +114,7 @@ RSpec.describe "PublicKeyCredential" do
     context "when authentication extension input" do
       context "is not received" do
         let(:attestation_response) do
-          allow_any_instance_of(WebAuthn::FakeAuthenticator::AuthenticatorData)
-            .to receive(:extensions)
-            .and_return(nil)
-
-          response = client.create(challenge: raw_challenge)["response"]
+          response = client.create(challenge: raw_challenge, extensions: nil)["response"]
 
           WebAuthn::AuthenticatorAttestationResponse.new(
             attestation_object: response["attestationObject"],
@@ -135,11 +131,10 @@ RSpec.describe "PublicKeyCredential" do
 
       context "is received" do
         let(:attestation_response) do
-          allow_any_instance_of(WebAuthn::FakeAuthenticator::AuthenticatorData)
-            .to receive(:extensions)
-            .and_return({ "txAuthSimple" => "Could you please verify yourself?" })
-
-          response = client.create(challenge: raw_challenge)["response"]
+          response = client.create(
+            challenge: raw_challenge,
+            extensions: { "txAuthSimple" => "Could you please verify yourself?" }
+          )["response"]
 
           WebAuthn::AuthenticatorAttestationResponse.new(
             attestation_object: response["attestationObject"],

--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -92,5 +92,23 @@ RSpec.describe "PublicKeyCredential" do
         }.to raise_error(WebAuthn::ChallengeVerificationError)
       end
     end
+
+    context "when clientExtensionResults is received" do
+      let(:public_key_credential) do
+        WebAuthn::PublicKeyCredentialWithAttestation.new(
+          type: type,
+          id: id,
+          raw_id: raw_id,
+          client_extension_outputs: { "appid" => "true" },
+          response: attestation_response
+        )
+      end
+
+      it "works" do
+        expect(public_key_credential.verify(challenge)).to be_truthy
+
+        expect(public_key_credential.client_extension_outputs).to eq({ "appid" => "true" })
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Add the possibility of accessing to the client and authenticator extensions outputs in the PublicKeyCredential's models, so that it can be manually validated by the user according to their expectations.

## Why

Extracted from WebAuthn spec in the sections [7.1 Registering a New Credential](https://www.w3.org/TR/webauthn-2/#sctn-registering-a-new-credential) (step 17) and [7.2 Verifying an Authentication Assertion](https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion) (step 18):

> Verify that the values of the client extension outputs in clientExtensionResults and the authenticator extension outputs in the extensions in authData are as expected, considering the client extension input values that were given in options.extensions and any specific policy of the Relying Party regarding unsolicited extensions, i.e., those that were not specified as part of options.extensions. In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
>
> Note: Client platforms MAY enact local policy that sets additional authenticator extensions or client extensions and thus cause values to appear in the authenticator extension outputs or client extension outputs that were not originally specified as part of options.extensions. Relying Parties MUST be prepared to handle such situations, whether it be to ignore the unsolicited extensions or reject the attestation. The Relying Party can make this decision based on local policy and the extensions in use.
>
> Note: Since all extensions are OPTIONAL for both the client and the authenticator, the Relying Party MUST also be prepared to handle cases where none or not all of the requested extensions were acted upon.