### PR TITLE
Add optional origin argument to AuthenticatorAttestationResponse#verify

### DIFF
--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,10 +9,10 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, user_verification: nil)
+    def verify(challenge, expected_origin = nil, user_verification: nil)
       super
 
-      response.verify(encoder.decode(challenge), user_verification: user_verification)
+      response.verify(encoder.decode(challenge), expected_origin, user_verification: user_verification)
 
       true
     end

--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe "PublicKeyCredential" do
       expect(public_key_credential.sign_count).to eq(0)
     end
 
+    context 'with valid origin as an argument' do
+      before do
+        WebAuthn.configuration.origin = nil
+      end
+
+      it 'works' do
+        expect(public_key_credential.verify(challenge, origin)).to be_truthy
+
+        expect(public_key_credential.id).not_to be_empty
+        expect(public_key_credential.public_key).not_to be_empty
+        expect(public_key_credential.sign_count).to eq(0)
+      end
+    end
+
     context "when type is invalid" do
       context "because it is missing" do
         let(:type) { nil }


### PR DESCRIPTION
Currently, the origin is configurable to a single value through the webauthn config. This value is expected to match `window.location.origin` during the registration and authentication process. This won't work for the multi-tenant apps which can have multiple origins, so the origin can't be dynamically verified since it can be a single value in the config. To fix this issue, I've added an arg to pass expected origin when the public key credential is verified. 