### PR TITLE
Rubocop: ignore vendor directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   DisabledByDefault: true
   Exclude:
     - "gemfiles/**/*"
+    - "vendor/**/*"
 
 Bundler:
   Enabled: true


### PR DESCRIPTION
When bundler installs gems to the vendor directory, rubocop by picks up their configuration and tries to lint these files as well, leading to false positives.

Ran into this while trying to run Rubocop for https://github.com/cedarcode/webauthn-ruby/pull/296 locally.