### PR TITLE
Update Rubocop to 0.86

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Layout:
 Layout/ClassStructure:
   Enabled: true
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Layout/FirstMethodArgumentLineBreak:
   Enabled: true
 
@@ -38,7 +41,22 @@ Layout/MultilineAssignmentLayout:
 Layout/MultilineMethodArgumentLineBreaks:
   Enabled: true
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Lint:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
   Enabled: true
 
 Naming:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -139,7 +139,7 @@ def create_root_certificate(key)
     extension_factory.create_extension("keyUsage", "keyCertSign,cRLSign", true),
   ]
 
-  certificate.sign(key, OpenSSL::Digest::SHA256.new)
+  certificate.sign(key, "SHA256")
 
   certificate
 end
@@ -154,7 +154,7 @@ def issue_certificate(ca_certificate, ca_key, key, name: nil)
   certificate.not_after = Time.now + 60
   certificate.public_key = key
 
-  certificate.sign(ca_key, OpenSSL::Digest::SHA256.new)
+  certificate.sign(ca_key, "SHA256")
 
   certificate
 end

--- a/spec/webauthn/attestation_statement/android_key_spec.rb
+++ b/spec/webauthn/attestation_statement/android_key_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "AndroidKey attestation" do
 
     let(:authenticator_data_bytes) do
       WebAuthn::FakeAuthenticator::AuthenticatorData.new(
-        rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
+        rp_id_hash: OpenSSL::Digest.digest("SHA256", "RP"),
         credential: { id: "0".b * 16, public_key: credential_key.public_key },
       ).serialize
     end
@@ -66,7 +66,7 @@ RSpec.describe "AndroidKey attestation" do
       extension_factory.issuer_certificate = certificate
       certificate.extensions = attestation_certificate_extensions
 
-      certificate.sign(root_key, OpenSSL::Digest::SHA256.new)
+      certificate.sign(root_key, "SHA256")
 
       certificate.to_der
     end

--- a/spec/webauthn/attestation_statement/android_safetynet_spec.rb
+++ b/spec/webauthn/attestation_statement/android_safetynet_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe WebAuthn::AttestationStatement::AndroidSafetynet do
 
     let(:authenticator_data_bytes) do
       WebAuthn::FakeAuthenticator::AuthenticatorData.new(
-        rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
+        rp_id_hash: OpenSSL::Digest.digest("SHA256", "RP"),
         credential: { id: "0".b * 16, public_key: credential_key.public_key },
       ).serialize
     end
@@ -63,7 +63,7 @@ RSpec.describe WebAuthn::AttestationStatement::AndroidSafetynet do
     end
 
     context "when nonce is not set to the base64 of the SHA256 of authData + clientDataHash" do
-      let(:nonce) { Base64.strict_encode64(OpenSSL::Digest::SHA256.digest("something else")) }
+      let(:nonce) { Base64.strict_encode64(OpenSSL::Digest.digest("SHA256", "something else")) }
 
       it "returns false" do
         expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy

--- a/spec/webauthn/attestation_statement/fido_u2f_spec.rb
+++ b/spec/webauthn/attestation_statement/fido_u2f_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "FidoU2f attestation" do
 
     let(:authenticator_data_bytes) do
       WebAuthn::FakeAuthenticator::AuthenticatorData.new(
-        rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
+        rp_id_hash: OpenSSL::Digest.digest("SHA256", "RP"),
         credential: { id: "0".b * 16, public_key: credential_public_key },
         aaguid: WebAuthn::AuthenticatorData::AttestedCredentialData::ZEROED_AAGUID
       ).serialize
@@ -130,7 +130,7 @@ RSpec.describe "FidoU2f attestation" do
     context "when the AAGUID is invalid" do
       let(:authenticator_data_bytes) do
         WebAuthn::FakeAuthenticator::AuthenticatorData.new(
-          rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
+          rp_id_hash: OpenSSL::Digest.digest("SHA256", "RP"),
           credential: { id: "0".b * 16, public_key: credential_public_key },
           aaguid: SecureRandom.random_bytes(16)
         ).serialize

--- a/spec/webauthn/attestation_statement/none_spec.rb
+++ b/spec/webauthn/attestation_statement/none_spec.rb
@@ -7,7 +7,7 @@ require "webauthn/attestation_statement/none"
 RSpec.describe "none attestation" do
   let(:authenticator_data_bytes) do
     WebAuthn::FakeAuthenticator::AuthenticatorData.new(
-      rp_id_hash: OpenSSL::Digest::SHA256.digest("localhost"),
+      rp_id_hash: OpenSSL::Digest.digest("SHA256", "localhost"),
       aaguid: 0.chr * 16,
     ).serialize
   end

--- a/spec/webauthn/attestation_statement/packed_spec.rb
+++ b/spec/webauthn/attestation_statement/packed_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Packed attestation" do
 
     let(:authenticator_data_bytes) do
       WebAuthn::FakeAuthenticator::AuthenticatorData.new(
-        rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
+        rp_id_hash: OpenSSL::Digest.digest("SHA256", "RP"),
         credential: { id: "0".b * 16, public_key: credential_key.public_key },
       ).serialize
     end
@@ -113,7 +113,7 @@ RSpec.describe "Packed attestation" do
           extension_factory.create_extension("basicConstraints", attestation_certificate_basic_constraints, true),
         ]
 
-        certificate.sign(root_key, OpenSSL::Digest::SHA256.new)
+        certificate.sign(root_key, "SHA256")
 
         certificate.to_der
       end
@@ -139,7 +139,7 @@ RSpec.describe "Packed attestation" do
           extension_factory.create_extension("keyUsage", "keyCertSign,cRLSign", true),
         ]
 
-        root_certificate.sign(root_key, OpenSSL::Digest::SHA256.new)
+        root_certificate.sign(root_key, "SHA256")
 
         root_certificate
       end

--- a/spec/webauthn/attestation_statement/tpm_spec.rb
+++ b/spec/webauthn/attestation_statement/tpm_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "TPM attestation statement" do
 
       let(:authenticator_data_bytes) do
         WebAuthn::FakeAuthenticator::AuthenticatorData.new(
-          rp_id_hash: OpenSSL::Digest::SHA256.digest("RP"),
+          rp_id_hash: OpenSSL::Digest.digest("SHA256", "RP"),
           credential: { id: "0".b * 16, public_key: credential_key.public_key },
         ).serialize
       end
@@ -46,7 +46,7 @@ RSpec.describe "TPM attestation statement" do
           extension_factory.create_extension("subjectAltName", "ASN1:SEQUENCE:dir_seq", aik_certificate_san_critical),
         ]
 
-        cert.sign(root_key, OpenSSL::Digest::SHA256.new)
+        cert.sign(root_key, "SHA256")
 
         cert
       end

--- a/spec/webauthn/authenticator_data_spec.rb
+++ b/spec/webauthn/authenticator_data_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WebAuthn::AuthenticatorData do
     ).serialize
   end
 
-  let(:rp_id_hash) { OpenSSL::Digest::SHA256.digest("localhost") }
+  let(:rp_id_hash) { OpenSSL::Digest.digest("SHA256", "localhost") }
   let(:sign_count) { 42 }
   let(:user_present) { true }
   let(:user_verified) { false }

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -48,6 +48,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug", "~> 11.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "0.80.1"
+  spec.add_development_dependency "rubocop", "0.86"
   spec.add_development_dependency "rubocop-rspec", "~> 1.38.1"
 end


### PR DESCRIPTION
Enabling new cops, only Lint/DeprecatedOpenSSLConstant (https://github.com/rubocop-hq/rubocop/pull/7950) needed correcting.