### PR TITLE
refactor: remove `icon` from `user` in public key options

### DIFF
--- a/lib/webauthn/public_key_credential/entity.rb
+++ b/lib/webauthn/public_key_credential/entity.rb
@@ -5,11 +5,10 @@ require "awrence"
 module WebAuthn
   class PublicKeyCredential
     class Entity
-      attr_reader :name, :icon
+      attr_reader :name
 
-      def initialize(name:, icon: nil)
+      def initialize(name:)
         @name = name
-        @icon = icon
       end
 
       def as_json
@@ -37,7 +36,7 @@ module WebAuthn
       end
 
       def attributes
-        [:name, :icon]
+        [:name]
       end
     end
   end

--- a/spec/webauthn/public_key_credential/creation_options_spec.rb
+++ b/spec/webauthn/public_key_credential/creation_options_spec.rb
@@ -111,14 +111,12 @@ RSpec.describe WebAuthn::PublicKeyCredential::CreationOptions do
     options = WebAuthn::PublicKeyCredential::CreationOptions.new(
       rp: {
         id: "rp-id",
-        name: "rp-name",
-        icon: "rp-icon-url"
+        name: "rp-name"
       },
       user: {
         id: "user-id",
         name: "user-name",
-        display_name: "user-display-name",
-        icon: "user-icon-url"
+        display_name: "user-display-name"
       },
       pub_key_cred_params: [{ type: "public-key", alg: -7 }],
       timeout: 10_000,
@@ -134,9 +132,9 @@ RSpec.describe WebAuthn::PublicKeyCredential::CreationOptions do
 
     hash = options.as_json
 
-    expect(hash[:rp]).to eq(id: "rp-id", name: "rp-name", icon: "rp-icon-url")
+    expect(hash[:rp]).to eq(id: "rp-id", name: "rp-name")
     expect(hash[:user]).to eq(
-      id: "user-id", name: "user-name", icon: "user-icon-url", displayName: "user-display-name"
+      id: "user-id", name: "user-name", displayName: "user-display-name"
     )
     expect(hash[:pubKeyCredParams]).to eq([{ type: "public-key", alg: -7 }])
     expect(hash[:timeout]).to eq(10_000)


### PR DESCRIPTION
## What

Remove the the image URL field from public key credential creation options.

## Why

Removing it since [it was removed from the spec](https://github.com/w3c/webauthn/pull/1337).