### PR TITLE
refactor: update cose & tpm-key_attestation runtime dependencies

### DIFF
--- a/lib/cose/rsapkcs1_algorithm.rb
+++ b/lib/cose/rsapkcs1_algorithm.rb
@@ -40,4 +40,11 @@ end
 COSE::Algorithm.register(RSAPKCS1Algorithm.new(-257, "RS256", hash_function: "SHA256"))
 COSE::Algorithm.register(RSAPKCS1Algorithm.new(-258, "RS384", hash_function: "SHA384"))
 COSE::Algorithm.register(RSAPKCS1Algorithm.new(-259, "RS512", hash_function: "SHA512"))
+
+# Patch openssl-signature_algorithm gem to support discouraged/deprecated RSA-PKCS#1 with SHA-1
+# (RS1 in JOSE/COSE terminology) algorithm needed for WebAuthn.
+OpenSSL::SignatureAlgorithm::RSAPKCS1.const_set(
+  :ACCEPTED_HASH_FUNCTIONS,
+  OpenSSL::SignatureAlgorithm::RSAPKCS1::ACCEPTED_HASH_FUNCTIONS + ["SHA1"]
+)
 COSE::Algorithm.register(RSAPKCS1Algorithm.new(-65535, "RS1", hash_function: "SHA1"))

--- a/spec/conformance/Gemfile.lock
+++ b/spec/conformance/Gemfile.lock
@@ -6,11 +6,11 @@ PATH
       awrence (~> 1.1)
       bindata (~> 2.4)
       cbor (~> 0.5.9)
-      cose (~> 1.0)
+      cose (~> 1.1)
       openssl (~> 2.0)
       safety_net_attestation (~> 0.4.0)
       securecompare (~> 1.0)
-      tpm-key_attestation (~> 0.9.0)
+      tpm-key_attestation (~> 0.10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -21,9 +21,9 @@ GEM
     bindata (2.4.7)
     byebug (11.0.1)
     cbor (0.5.9.6)
-    cose (1.0.0)
+    cose (1.2.0)
       cbor (~> 0.5.9)
-      openssl-signature_algorithm (~> 0.4.0)
+      openssl-signature_algorithm (~> 1.0)
     fido_metadata (0.4.0)
       jwt (~> 2.0)
     jwt (2.2.1)
@@ -31,7 +31,7 @@ GEM
     mustermann (1.1.0)
       ruby2_keywords (~> 0.0.1)
     openssl (2.2.0)
-    openssl-signature_algorithm (0.4.0)
+    openssl-signature_algorithm (1.0.0)
     rack (2.0.8)
     rack-contrib (2.1.0)
       rack (~> 2.0)
@@ -55,9 +55,9 @@ GEM
       sinatra (= 2.0.8.1)
       tilt (~> 2.0)
     tilt (2.0.10)
-    tpm-key_attestation (0.9.0)
+    tpm-key_attestation (0.10.0)
       bindata (~> 2.4)
-      openssl-signature_algorithm (~> 0.4.0)
+      openssl-signature_algorithm (~> 1.0)
 
 PLATFORMS
   ruby

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -37,11 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "awrence", "~> 1.1"
   spec.add_dependency "bindata", "~> 2.4"
   spec.add_dependency "cbor", "~> 0.5.9"
-  spec.add_dependency "cose", "~> 1.0"
+  spec.add_dependency "cose", "~> 1.1"
   spec.add_dependency "openssl", "~> 2.0"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
   spec.add_dependency "securecompare", "~> 1.0"
-  spec.add_dependency "tpm-key_attestation", "~> 0.9.0"
+  spec.add_dependency "tpm-key_attestation", "~> 0.10.0"
 
   spec.add_development_dependency "appraisal", "~> 2.3.0"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"


### PR DESCRIPTION
As a side-effect this will add support for `ES256K` credentials, because of https://github.com/cedarcode/openssl-signature_algorithm/commit/bc11db7ed4dedd7f4543bba332aa18d6dfab8b51 and https://github.com/cedarcode/cose-ruby/commit/d44bbcaa9a1996c3cdfd6d06a656d64f919dfcd6.