### PR TITLE
Add Github action to prevent merging of fixup commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,21 @@
+# Syntax reference:
+# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+name: Git Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  # Fixup commits are OK in pull requests, but should generally be squashed
+  # before merging to master, e.g. using `git rebase -i --autosquash master`.
+  # See https://github.com/marketplace/actions/block-autosquash-commits
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - name: Block autosquash commits
+        uses: xt0rted/block-autosquash-commits-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixup commits are OK in pull requests, but without a check like this one though, it's easy to forget to squash them away before merging to master.

See https://thoughtbot.com/blog/autosquashing-git-commits

Followed this guide: https://github.com/marketplace/actions/block-fixup-commit-merge