### PR TITLE
Allow specifying a user handle for `FakeClient` `get`.

### DIFF
--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -73,7 +73,8 @@ module WebAuthn
             user_present: true,
             user_verified: false,
             sign_count: nil,
-            extensions: nil)
+            extensions: nil,
+            user_handle: nil)
       rp_id ||= URI.parse(origin).host
 
       client_data_json = data_json_for(:get, encoder.decode(challenge))
@@ -97,7 +98,7 @@ module WebAuthn
           "clientDataJSON" => encoder.encode(client_data_json),
           "authenticatorData" => encoder.encode(assertion[:authenticator_data]),
           "signature" => encoder.encode(assertion[:signature]),
-          "userHandle" => nil
+          "userHandle" => user_handle ? encoder.encode(user_handle) : nil
         }
       }
     end


### PR DESCRIPTION
Right now, the fake client is not easy to use to emulate a resident key. However, whether the registration is a resident key is not included in the attestation/assertion data, so we can just include it in the `get` response (which this PR does).