### PR TITLE
feat: allow passing expected origin to credential verify

### DIFF
--- a/lib/webauthn/public_key_credential_with_assertion.rb
+++ b/lib/webauthn/public_key_credential_with_assertion.rb
@@ -9,11 +9,12 @@ module WebAuthn
       WebAuthn::AuthenticatorAssertionResponse
     end
 
-    def verify(challenge, public_key:, sign_count:, user_verification: nil)
+    def verify(challenge, expected_origin = nil, public_key:, sign_count:, user_verification: nil)
       super
 
       response.verify(
         encoder.decode(challenge),
+        expected_origin,
         public_key: encoder.decode(public_key),
         sign_count: sign_count,
         user_verification: user_verification

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,10 +9,10 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, user_verification: nil)
+    def verify(challenge, expected_origin = nil, user_verification: nil)
       super
 
-      response.verify(encoder.decode(challenge), user_verification: user_verification)
+      response.verify(encoder.decode(challenge), expected_origin, user_verification: user_verification)
 
       true
     end

--- a/spec/webauthn/public_key_credential_with_assertion_spec.rb
+++ b/spec/webauthn/public_key_credential_with_assertion_spec.rb
@@ -129,6 +129,19 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
       end
     end
 
+    context "when the origin is not what's expected" do
+      it "fails" do
+        expect do
+          public_key_credential.verify(
+            challenge,
+            "https://example.com/",
+            public_key: credential_public_key,
+            sign_count: credential_sign_count
+          )
+        end.to raise_error(WebAuthn::OriginVerificationError)
+      end
+    end
+
     context "when clientExtensionResults" do
       context "is not received" do
         let(:public_key_credential) do

--- a/spec/webauthn/public_key_credential_with_attestation_spec.rb
+++ b/spec/webauthn/public_key_credential_with_attestation_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe "PublicKeyCredentialWithAttestation" do
       end
     end
 
+    context "when the origin is not what's expected" do
+      it "fails" do
+        expect {
+          public_key_credential.verify(challenge, "https://example.com/")
+        }.to raise_error(WebAuthn::OriginVerificationError)
+      end
+    end
+
     context "when clientExtensionResults" do
       context "are not received" do
         let(:public_key_credential) do


### PR DESCRIPTION
If you have an app that serves from multiple domain names, you need to
be able to pass the expected origin to the `verify` method of
PublicKeyCredentialWithAssertion and PublicKeyCredentialWithAttestation