### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.