### PR TITLE
Prepare for OpenSSL 3 compatibility

### DIFF
--- a/lib/webauthn/attestation_statement/tpm.rb
+++ b/lib/webauthn/attestation_statement/tpm.rb
@@ -42,7 +42,7 @@ module WebAuthn
             OpenSSL::Digest.digest(cose_algorithm.hash_function, certified_extra_data),
             signature_algorithm: tpm_algorithm[:signature],
             hash_algorithm: tpm_algorithm[:hash],
-            root_certificates: root_certificates(aaguid: aaguid)
+            trusted_certificates: root_certificates(aaguid: aaguid)
           )
 
         key_attestation.valid? && key_attestation.key && key_attestation.key.to_pem == key.to_pem
@@ -54,7 +54,7 @@ module WebAuthn
       end
 
       def default_root_certificates
-        ::TPM::KeyAttestation::ROOT_CERTIFICATES
+        ::TPM::KeyAttestation::TRUSTED_CERTIFICATES
       end
 
       def tpm_algorithm

--- a/lib/webauthn/fake_authenticator.rb
+++ b/lib/webauthn/fake_authenticator.rb
@@ -95,7 +95,7 @@ module WebAuthn
     attr_reader :credentials
 
     def new_credential
-      [SecureRandom.random_bytes(16), OpenSSL::PKey::EC.new("prime256v1").generate_key, 0]
+      [SecureRandom.random_bytes(16), OpenSSL::PKey::EC.generate("prime256v1"), 0]
     end
 
     def hashed(target)

--- a/lib/webauthn/fake_authenticator/authenticator_data.rb
+++ b/lib/webauthn/fake_authenticator/authenticator_data.rb
@@ -15,7 +15,7 @@ module WebAuthn
         rp_id_hash:,
         credential: {
           id: SecureRandom.random_bytes(16),
-          public_key: OpenSSL::PKey::EC.new("prime256v1").generate_key.public_key
+          public_key: OpenSSL::PKey::EC.generate("prime256v1").public_key
         },
         sign_count: 0,
         user_present: true,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,7 +102,7 @@ def create_rsa_key
 end
 
 def create_ec_key
-  OpenSSL::PKey::EC.new("prime256v1").generate_key
+  OpenSSL::PKey::EC.generate("prime256v1")
 end
 
 X509_V3 = 2

--- a/spec/webauthn/attestation_statement/fido_u2f_spec.rb
+++ b/spec/webauthn/attestation_statement/fido_u2f_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "FidoU2f attestation" do
         let(:credential_public_key) do
           WebAuthn.configuration.algorithms << "ES384"
 
-          OpenSSL::PKey::EC.new("secp384r1").generate_key.public_key
+          OpenSSL::PKey::EC.generate("secp384r1").public_key
         end
 
         it "fails" do
@@ -119,7 +119,7 @@ RSpec.describe "FidoU2f attestation" do
       end
 
       context "because it is not of the correct curve" do
-        let(:attestation_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key }
+        let(:attestation_key) { OpenSSL::PKey::EC.generate("secp384r1") }
 
         it "fails" do
           expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy

--- a/spec/webauthn/attestation_statement/packed_spec.rb
+++ b/spec/webauthn/attestation_statement/packed_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Packed attestation" do
         let(:credential_key) do
           WebAuthn.configuration.algorithms << "ES512"
 
-          OpenSSL::PKey::EC.new("secp521r1").generate_key
+          OpenSSL::PKey::EC.generate("secp521r1")
         end
 
         it "fails" do

--- a/spec/webauthn/attestation_statement/tpm_spec.rb
+++ b/spec/webauthn/attestation_statement/tpm_spec.rb
@@ -139,10 +139,10 @@ RSpec.describe "TPM attestation statement" do
 
       around do |example|
         silence_warnings do
-          original_tpm_certificates = ::TPM::KeyAttestation::ROOT_CERTIFICATES
-          ::TPM::KeyAttestation::ROOT_CERTIFICATES = tpm_certificates
+          original_tpm_certificates = ::TPM::KeyAttestation::TRUSTED_CERTIFICATES
+          ::TPM::KeyAttestation::TRUSTED_CERTIFICATES = tpm_certificates
           example.run
-          ::TPM::KeyAttestation::ROOT_CERTIFICATES = original_tpm_certificates
+          ::TPM::KeyAttestation::TRUSTED_CERTIFICATES = original_tpm_certificates
         end
       end
 

--- a/spec/webauthn/public_key_spec.rb
+++ b/spec/webauthn/public_key_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "PublicKey" do
 
         cose_key
       end
-      let(:key) { OpenSSL::PKey::EC.new("prime256v1").generate_key }
+      let(:key) { OpenSSL::PKey::EC.generate("prime256v1") }
       let(:webauthn_public_key) { WebAuthn::PublicKey.new(cose_key: cose_key) }
 
       it "works" do
@@ -143,7 +143,7 @@ RSpec.describe "PublicKey" do
 
       context "when it was signed with a different key" do
         let(:signature) do
-          OpenSSL::PKey::EC.new("prime256v1").generate_key.sign(
+          OpenSSL::PKey::EC.generate("prime256v1").sign(
             hash_algorithm,
             to_be_signed
           )

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bindata", "~> 2.4"
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "cose", "~> 1.1"
-  spec.add_dependency "openssl", "~> 2.2"
+  spec.add_dependency "openssl", ">= 2.2", "< 3.1"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
   spec.add_dependency "tpm-key_attestation", "~> 0.10.0"
 

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cose", "~> 1.1"
   spec.add_dependency "openssl", ">= 2.2", "< 3.1"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
-  spec.add_dependency "tpm-key_attestation", "~> 0.10.0"
+  spec.add_dependency "tpm-key_attestation", "~> 0.11.0"
 
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"
   spec.add_development_dependency "byebug", "~> 11.0"


### PR DESCRIPTION
This is not enough for OpenSSL 3 compatibility as various dependencies still need fixing, but as far as I know, it should fix all incompatible code from the `webauthn-ruby` gem itself without breaking compatibility with the 2.2 version of the `openssl` gem.

Actual compatibility with OpenSSL 3 would require at least the following to be merged:
- https://github.com/cedarcode/tpm-key_attestation/pull/16
- https://github.com/cedarcode/openssl-signature_algorithm/pull/5
- https://github.com/cedarcode/cose-ruby/pull/61