### PR TITLE
Updated OpenSSL requirement to avoid build issues on newer systems

### DIFF
--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bindata", "~> 2.4"
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "cose", "~> 1.1"
-  spec.add_dependency "openssl", "~> 2.2"
+  spec.add_dependency "openssl", ">= 2.2", "< 3.1"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
   spec.add_dependency "tpm-key_attestation", "~> 0.10.0"
 


### PR DESCRIPTION
Updated the OpenSSL version requirement to avoid build issues on newer systems. For example Ubuntu 22.04 comes with OpenSSL v3 by default. This gem doesn't use any v2 specific functionality and the upgrade doesn't cause any side effects.

I added the `<3.1` as an upper bound and potential breaking API changes. This could be revised in the future when it is released.

All the [tests](https://github.com/itay-grudev/webauthn-ruby/runs/6905678939) passed with:
```
  Fetching openssl 3.0.0
  Installing openssl 3.0.0 with native extensions
```
  
P.S. I would really appreciate it if you release this as `v3.0.0.alpha2` so I don't have to run a fork of our own and it's blocking our new feature release.
P.P.S. Ping me if you need any additional changes.