### PR TITLE
Fix version number typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Ability to define multiple relying parties with the introduction of the `WebAuthn::RelyingParty` class ([@padulafacundo], [@brauliomartinezlm])
 
-## [v2.5.1] - 2022-07-13
+## [v2.5.2] - 2022-07-13
 
 ### Added
 
@@ -341,7 +341,7 @@ Note: Both additions should help making it compatible with Chrome for Android 70
 - Works with ruby 2.5
 
 [v3.0.0.alpha1]: https://github.com/cedarcode/webauthn-ruby/compare/2-stable...v3.0.0.alpha1/
-[v2.5.2]: https://github.com/cedarcode/webauthn-ruby/compare/v2.5.0...v2.5.2/
+[v2.5.2]: https://github.com/cedarcode/webauthn-ruby/compare/v2.5.1...v2.5.2/
 [v2.5.1]: https://github.com/cedarcode/webauthn-ruby/compare/v2.5.0...v2.5.1/
 [v2.5.0]: https://github.com/cedarcode/webauthn-ruby/compare/v2.4.1...v2.5.0/
 [v2.4.1]: https://github.com/cedarcode/webauthn-ruby/compare/v2.4.0...v2.4.1/


### PR DESCRIPTION
I think there is a typo in CHANGELOG.md. The version released a few days ago should be 2.5.2, not 2.5.1.
https://github.com/cedarcode/webauthn-ruby/releases/tag/v2.5.2

 (and in fact, there are 2 entries with version number 2.5.1)