### PR TITLE
Allow to pass expected origin to verify

### DIFF
--- a/lib/webauthn/public_key_credential_with_assertion.rb
+++ b/lib/webauthn/public_key_credential_with_assertion.rb
@@ -9,11 +9,12 @@ module WebAuthn
       WebAuthn::AuthenticatorAssertionResponse
     end
 
-    def verify(challenge, public_key:, sign_count:, user_verification: nil)
+    def verify(challenge, expected_origin = nil, public_key:, sign_count:, user_verification: nil)
       super
 
       response.verify(
         encoder.decode(challenge),
+        expected_origin,
         public_key: encoder.decode(public_key),
         sign_count: sign_count,
         user_verification: user_verification

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,10 +9,10 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, user_verification: nil)
+    def verify(challenge, expected_origin = nil, user_verification: nil)
       super
 
-      response.verify(encoder.decode(challenge), user_verification: user_verification)
+      response.verify(encoder.decode(challenge), expected_origin, user_verification: user_verification)
 
       true
     end

--- a/spec/webauthn/public_key_credential_with_assertion_spec.rb
+++ b/spec/webauthn/public_key_credential_with_assertion_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
       WebAuthn::AuthenticatorAssertionResponse.new(
         authenticator_data: response["authenticatorData"],
         client_data_json: response["clientDataJSON"],
-        signature: response["signature"],
+        signature: response["signature"]
       )
     end
 
@@ -37,7 +37,7 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
         type: credential_type,
         id: credential_id,
         raw_id: credential_raw_id,
-        response: assertion_response,
+        response: assertion_response
       )
     end
 


### PR DESCRIPTION
Both

- `WebAuthn::AuthenticatorAttestationResponse#verify` and 
- `WebAuthn::AuthenticatorAssertionResponse#verify`

accept the parameter `expected_origin`, but the calling methods 

- `PublicKeyCredentialWithAttestation#verify` and 
- `PublicKeyCredentialWithAssertion#verify`, 

respectively, do not.

We have a multi-tenant system where each tenant has its own subdomain and need to be able to pass the origin when validating the data.