### PR TITLE
Mention passkeys, add Apple dev docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Makes your Ruby/Rails web server become a functional [WebAuthn Relying Party](ht
 
 Takes care of the [server-side operations](https://www.w3.org/TR/webauthn/#rp-operations) needed to
 [register](https://www.w3.org/TR/webauthn/#registration) or [authenticate](https://www.w3.org/TR/webauthn/#authentication)
-a user [credential](https://www.w3.org/TR/webauthn/#public-key-credential), including the necessary cryptographic checks.
+a user's [public key credential](https://www.w3.org/TR/webauthn/#public-key-credential) (also called a "passkey"), including the necessary cryptographic checks.
 
 ## Table of Contents
 
@@ -52,7 +52,7 @@ WebAuthn (Web Authentication) is a W3C standard for secure public-key authentica
 
 - WebAuthn [W3C Recommendation](https://www.w3.org/TR/webauthn/) (i.e. "The Standard")
 - [Web Authentication API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API) in MDN
-- How to use [WebAuthn in Android apps](https://developers.google.com/identity/fido/android/native-apps)
+- How to use WebAuthn in native [Android](https://developers.google.com/identity/fido/android/native-apps) or [macOS/iOS/iPadOS](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication) apps.
 - [Security Benefits for WebAuthn Servers (a.k.a Relying Parties)](https://www.w3.org/TR/webauthn/#sctn-rp-benefits)
 
 ## Prerequisites


### PR DESCRIPTION
With iOS 16 releasing today this is going to be searched for more often I expect. @brauliomartinezlm can you add the [passkey](https://github.com/topics/passkey)/[passkeys](https://github.com/topics/passkeys) topics to the repo?

The podcast [Security. Cryptography. Whatever: Passkeys feat. Adam Langley](https://securitycryptographywhatever.buzzsprout.com/1822302/11122508-passkeys-feat-adam-langley) has an explanation on how the term 'passkey' came to be, but that seemed overkill for the readme.