### PR TITLE
Add support for optional authenticator_attachment in PublicKeyCredential

### DIFF
--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -60,6 +60,7 @@ module WebAuthn
         "type" => "public-key",
         "id" => internal_encoder.encode(id),
         "rawId" => encoder.encode(id),
+        "authenticatorAttachment" => 'platform',
         "clientExtensionResults" => extensions,
         "response" => {
           "attestationObject" => encoder.encode(attestation_object),
@@ -100,6 +101,7 @@ module WebAuthn
         "id" => internal_encoder.encode(assertion[:credential_id]),
         "rawId" => encoder.encode(assertion[:credential_id]),
         "clientExtensionResults" => extensions,
+        "authenticatorAttachment" => 'platform',
         "response" => {
           "clientDataJSON" => encoder.encode(client_data_json),
           "authenticatorData" => encoder.encode(assertion[:authenticator_data]),

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -4,7 +4,7 @@ require "webauthn/encoder"
 
 module WebAuthn
   class PublicKeyCredential
-    attr_reader :type, :id, :raw_id, :client_extension_outputs, :response
+    attr_reader :type, :id, :raw_id, :client_extension_outputs, :authenticator_attachment, :response
 
     def self.from_client(credential, relying_party: WebAuthn.configuration.relying_party)
       new(
@@ -12,6 +12,7 @@ module WebAuthn
         id: credential["id"],
         raw_id: relying_party.encoder.decode(credential["rawId"]),
         client_extension_outputs: credential["clientExtensionResults"],
+        authenticator_attachment: credential["authenticatorAttachment"],
         response: response_class.from_client(credential["response"], relying_party: relying_party),
         encoder: relying_party.encoder
       )
@@ -22,6 +23,7 @@ module WebAuthn
       id:,
       raw_id:,
       response:,
+      authenticator_attachment: nil,
       client_extension_outputs: {},
       encoder: WebAuthn.configuration.encoder
     )
@@ -29,6 +31,7 @@ module WebAuthn
       @id = id
       @raw_id = raw_id
       @client_extension_outputs = client_extension_outputs
+      @authenticator_attachment = authenticator_attachment
       @response = response
       @encoder = encoder
     end

--- a/spec/webauthn/public_key_credential_with_assertion_spec.rb
+++ b/spec/webauthn/public_key_credential_with_assertion_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
     let(:credential_raw_id) { credential[0] }
     let(:credential_id) { Base64.urlsafe_encode64(credential_raw_id) }
     let(:credential_type) { "public-key" }
+    let(:credential_authenticator_attachment) { 'platform' }
     let(:credential_public_key) { Base64.urlsafe_encode64(credential[1]) }
     let(:credential_sign_count) { credential[2] }
 
@@ -37,6 +38,7 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
         type: credential_type,
         id: credential_id,
         raw_id: credential_raw_id,
+        authenticator_attachment: credential_authenticator_attachment,
         response: assertion_response
       )
     end

--- a/spec/webauthn/public_key_credential_with_attestation_spec.rb
+++ b/spec/webauthn/public_key_credential_with_attestation_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "PublicKeyCredentialWithAttestation" do
         type: type,
         id: id,
         raw_id: raw_id,
+        authenticator_attachment: authenticator_attachment,
         response: attestation_response
       )
     end
@@ -22,6 +23,7 @@ RSpec.describe "PublicKeyCredentialWithAttestation" do
     let(:type) { "public-key" }
     let(:id) { Base64.urlsafe_encode64(raw_id) }
     let(:raw_id) { SecureRandom.random_bytes(16) }
+    let(:authenticator_attachment) { 'platform' }
 
     let(:attestation_response) do
       response = client.create(challenge: raw_challenge)["response"]


### PR DESCRIPTION
## Why

https://w3c.github.io/webauthn/#iface-pkcredential

Level 3 draft of WebAuthn adds an optional parameter `authenticatorAttachment` on `PublicKeyCredential` (and  `AuthenticatorAttestationResponse` and `AuthenticatorAssertionResponse` which inherits it, of course).

This field allows RP developers to detect whether the authentication was done using platform authenticator that always exists on that particular device, or cross-platform authenticator that only exists on that device temporarily.

In the latter case of using cross-platform authenticator, RP can prompt the user to register a platform authenticator so that the user won't lose the ability to sign in on that device.
> Note: If, as the result of a [registration](https://w3c.github.io/webauthn/#registration-ceremony) or [authentication ceremony](https://w3c.github.io/webauthn/#authentication-ceremony), [authenticatorAttachment](https://w3c.github.io/webauthn/#dom-publickeycredential-authenticatorattachment)'s value is "cross-platform" and concurrently [isUserVerifyingPlatformAuthenticatorAvailable](https://w3c.github.io/webauthn/#dom-publickeycredential-isuserverifyingplatformauthenticatoravailable) returns true, then the user employed a [roaming authenticator](https://w3c.github.io/webauthn/#roaming-authenticators) for this [ceremony](https://w3c.github.io/webauthn/#ceremony) while there is an available [platform authenticator](https://w3c.github.io/webauthn/#platform-authenticators). Thus the [Relying Party](https://w3c.github.io/webauthn/#relying-party) has the opportunity to prompt the user to register the available [platform authenticator](https://w3c.github.io/webauthn/#platform-authenticators), which may enable more streamlined user experience flows.

Since some vendors (I confirmed with Mac chrome) are already passing this optional parameter `authenticatorAttachment`, I want this gem to be able to support reading values from that field.

## What

Allow initializing `PublicKeyCredential` class with an optional argument `authenticator_attachment`

## Misc

I obtained the authenticator response returned from the client on sign-in (using dev-console), and ran `WebAuthn::Credential.from_get` on that response.
As you can see, I can now obtain the value of `authenticator_attachment`

![image](https://user-images.githubusercontent.com/24708144/190539890-eeb44149-a519-4772-b84e-5e34dab304d1.png)

