### PR TITLE
Add support for credential backup flags

### DIFF
--- a/lib/webauthn/authenticator_data.rb
+++ b/lib/webauthn/authenticator_data.rb
@@ -19,8 +19,8 @@ module WebAuthn
     struct :flags do
       bit1 :extension_data_included
       bit1 :attested_credential_data_included
-      bit1 :reserved_for_future_use_3
       bit1 :reserved_for_future_use_2
+      bit1 :backup_state
       bit1 :backup_eligibility
       bit1 :user_verified
       bit1 :reserved_for_future_use_1
@@ -60,6 +60,10 @@ module WebAuthn
 
     def credential_backup_eligible?
       flags.backup_eligibility == 1
+    end
+
+    def credential_backed_up?
+      flags.backup_state == 1
     end
 
     def attested_credential_data_included?

--- a/lib/webauthn/authenticator_data.rb
+++ b/lib/webauthn/authenticator_data.rb
@@ -19,9 +19,9 @@ module WebAuthn
     struct :flags do
       bit1 :extension_data_included
       bit1 :attested_credential_data_included
-      bit1 :reserved_for_future_use_4
       bit1 :reserved_for_future_use_3
       bit1 :reserved_for_future_use_2
+      bit1 :backup_eligibility
       bit1 :user_verified
       bit1 :reserved_for_future_use_1
       bit1 :user_present
@@ -56,6 +56,10 @@ module WebAuthn
 
     def user_verified?
       flags.user_verified == 1
+    end
+
+    def credential_backup_eligible?
+      flags.backup_eligibility == 1
     end
 
     def attested_credential_data_included?

--- a/lib/webauthn/fake_authenticator/authenticator_data.rb
+++ b/lib/webauthn/fake_authenticator/authenticator_data.rb
@@ -21,6 +21,7 @@ module WebAuthn
         user_present: true,
         user_verified: !user_present,
         backup_eligibility: false,
+        backup_state: false,
         aaguid: AAGUID,
         extensions: { "fakeExtension" => "fakeExtensionValue" }
       )
@@ -30,6 +31,7 @@ module WebAuthn
         @user_present = user_present
         @user_verified = user_verified
         @backup_eligibility = backup_eligibility
+        @backup_state = backup_state
         @aaguid = aaguid
         @extensions = extensions
       end
@@ -40,7 +42,13 @@ module WebAuthn
 
       private
 
-      attr_reader :rp_id_hash, :credential, :user_present, :user_verified, :extensions, :backup_eligibility
+      attr_reader :rp_id_hash,
+                  :credential,
+                  :user_present,
+                  :user_verified,
+                  :extensions,
+                  :backup_eligibility,
+                  :backup_state
 
       def flags
         [
@@ -49,7 +57,7 @@ module WebAuthn
             reserved_for_future_use_bit,
             bit(:user_verified),
             bit(:backup_eligibility),
-            reserved_for_future_use_bit,
+            bit(:backup_state),
             reserved_for_future_use_bit,
             attested_credential_data_included_bit,
             extension_data_included_bit
@@ -110,7 +118,12 @@ module WebAuthn
       end
 
       def context
-        { user_present: user_present, user_verified: user_verified, backup_eligibility: backup_eligibility }
+        {
+          user_present: user_present,
+          user_verified: user_verified,
+          backup_eligibility: backup_eligibility,
+          backup_state: backup_state
+        }
       end
 
       def cose_credential_public_key

--- a/lib/webauthn/fake_authenticator/authenticator_data.rb
+++ b/lib/webauthn/fake_authenticator/authenticator_data.rb
@@ -20,6 +20,7 @@ module WebAuthn
         sign_count: 0,
         user_present: true,
         user_verified: !user_present,
+        backup_eligibility: false,
         aaguid: AAGUID,
         extensions: { "fakeExtension" => "fakeExtensionValue" }
       )
@@ -28,6 +29,7 @@ module WebAuthn
         @sign_count = sign_count
         @user_present = user_present
         @user_verified = user_verified
+        @backup_eligibility = backup_eligibility
         @aaguid = aaguid
         @extensions = extensions
       end
@@ -38,7 +40,7 @@ module WebAuthn
 
       private
 
-      attr_reader :rp_id_hash, :credential, :user_present, :user_verified, :extensions
+      attr_reader :rp_id_hash, :credential, :user_present, :user_verified, :extensions, :backup_eligibility
 
       def flags
         [
@@ -46,7 +48,7 @@ module WebAuthn
             bit(:user_present),
             reserved_for_future_use_bit,
             bit(:user_verified),
-            reserved_for_future_use_bit,
+            bit(:backup_eligibility),
             reserved_for_future_use_bit,
             reserved_for_future_use_bit,
             attested_credential_data_included_bit,
@@ -108,7 +110,7 @@ module WebAuthn
       end
 
       def context
-        { user_present: user_present, user_verified: user_verified }
+        { user_present: user_present, user_verified: user_verified, backup_eligibility: backup_eligibility }
       end
 
       def cose_credential_public_key

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -52,6 +52,10 @@ module WebAuthn
       authenticator_data&.credential_backup_eligible?
     end
 
+    def backed_up?
+      authenticator_data&.credential_backed_up?
+    end
+
     private
 
     attr_reader :relying_party

--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -48,6 +48,10 @@ module WebAuthn
       authenticator_data.extension_data if authenticator_data&.extension_data_included?
     end
 
+    def backup_eligible?
+      authenticator_data&.credential_backup_eligible?
+    end
+
     private
 
     attr_reader :relying_party

--- a/spec/webauthn/authenticator_data_spec.rb
+++ b/spec/webauthn/authenticator_data_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe WebAuthn::AuthenticatorData do
       sign_count: sign_count,
       user_present: user_present,
       user_verified: user_verified,
-      backup_eligibility: backup_eligibility
+      backup_eligibility: backup_eligibility,
+      backup_state: backup_state,
     ).serialize
   end
 
@@ -18,6 +19,7 @@ RSpec.describe WebAuthn::AuthenticatorData do
   let(:user_present) { true }
   let(:user_verified) { false }
   let(:backup_eligibility) { false }
+  let(:backup_state) { false }
 
   let(:authenticator_data) { described_class.deserialize(serialized_authenticator_data) }
 
@@ -128,6 +130,22 @@ RSpec.describe WebAuthn::AuthenticatorData do
 
     context "when BE flag is not set" do
       let(:backup_eligibility) { false }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#credential_backed_up?" do
+    subject { authenticator_data.credential_backed_up? }
+
+    context "when BS flag is set" do
+      let(:backup_state) { true }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when BS flag is not set" do
+      let(:backup_state) { false }
 
       it { is_expected.to be_falsy }
     end

--- a/spec/webauthn/authenticator_data_spec.rb
+++ b/spec/webauthn/authenticator_data_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe WebAuthn::AuthenticatorData do
       rp_id_hash: rp_id_hash,
       sign_count: sign_count,
       user_present: user_present,
-      user_verified: user_verified
+      user_verified: user_verified,
+      backup_eligibility: backup_eligibility
     ).serialize
   end
 
@@ -16,6 +17,7 @@ RSpec.describe WebAuthn::AuthenticatorData do
   let(:sign_count) { 42 }
   let(:user_present) { true }
   let(:user_verified) { false }
+  let(:backup_eligibility) { false }
 
   let(:authenticator_data) { described_class.deserialize(serialized_authenticator_data) }
 
@@ -110,6 +112,22 @@ RSpec.describe WebAuthn::AuthenticatorData do
     context "when both UP and UV flag are not set" do
       let(:user_present) { false }
       let(:user_verified) { false }
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#credential_backup_eligible?" do
+    subject { authenticator_data.credential_backup_eligible? }
+
+    context "when BE flag is set" do
+      let(:backup_eligibility) { true }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when BE flag is not set" do
+      let(:backup_eligibility) { false }
 
       it { is_expected.to be_falsy }
     end


### PR DESCRIPTION
## What

Add ability to access the `backup_eligibility` and `backup_state` flags in the authenticator data. 

Introduces the methods `PublicKeyCredential#backup_eligible?` and `PublicKeyCredential#backed_up?` to access them.

## Why

Level 3 of the draft adds this flags to the Authenticator Data: https://w3c.github.io/webauthn/#sctn-credential-backup. Those flags can be used to get information about credential's backup eligibility and current backup state. With the introduction of multi-device FIDO credentials, this information can be useful for Relying Parties. According to the [documentation](https://w3c.github.io/webauthn/#sctn-credential-backup):

> The following is a non-exhaustive list of how [Relying Parties](https://w3c.github.io/webauthn/#relying-party) might use these [flags](https://w3c.github.io/webauthn/#authdata-flags):
>
> - Requiring additional [authenticators](https://w3c.github.io/webauthn/#authenticator):
>
>   When the [BE](https://w3c.github.io/webauthn/#authdata-flags-be) [flag](https://w3c.github.io/webauthn/#authdata-flags) is set to 0, the credential is a [single-device credential](https://w3c.github.io/webauthn/#single-device-credential) and the [generating authenticator](https://w3c.github.io/webauthn/#generating-authenticator) will never allow the credential to be backed up.
>
>   A [single-device credential](https://w3c.github.io/webauthn/#single-device-credential) is not resilient to single device loss. [Relying Parties](https://w3c.github.io/webauthn/#relying-party) SHOULD ensure that each [user account](https://w3c.github.io/webauthn/#user-account) has additional [authenticators](https://w3c.github.io/webauthn/#authenticator) [registered](https://w3c.github.io/webauthn/#registration-ceremony) and/or an account recovery process in place. For example, the user could be prompted to set up an additional [authenticator](https://w3c.github.io/webauthn/#authenticator), such as a [roaming authenticator](https://w3c.github.io/webauthn/#roaming-authenticators) or an [authenticator](https://w3c.github.io/webauthn/#authenticator) that is capable of [multi-device credentials](https://w3c.github.io/webauthn/#multi-device-credential).
>
> * Upgrading a user to a password-free account:
>
>    When the [BS](https://w3c.github.io/webauthn/#authdata-flags-bs) [flag](https://w3c.github.io/webauthn/#authdata-flags) changes from 0 to 1, the [authenticator](https://w3c.github.io/webauthn/#authenticator) is signaling that the [credential](https://w3c.github.io/webappsec-credential-management/#concept-credential) is backed up and is protected from single device loss.
>
>    The [Relying Party](https://w3c.github.io/webauthn/#relying-party) MAY choose to prompt the user to upgrade their account security and remove their password.
>
> * Adding an additional factor after a state change:
>
>   When the [BS](https://w3c.github.io/webauthn/#authdata-flags-bs) [flag](https://w3c.github.io/webauthn/#authdata-flags) changes from 1 to 0, the [authenticator](https://w3c.github.io/webauthn/#authenticator) is signaling that the [credential](https://w3c.github.io/webappsec-credential-management/#concept-credential) is no longer backed up, and no longer protected from single device loss. This could be the result of the user actions, such as disabling the backup service, or errors, such as issues with the backup service.
>
>   When this transition occurs, the [Relying Party](https://w3c.github.io/webauthn/#relying-party) SHOULD guide the user through a process to validate their other authentication factors. If the user does not have another credential for their account, they SHOULD be guided through adding an additional credential to ensure they do not lose access to their account. For example, the user could be prompted to set up an additional [authenticator](https://w3c.github.io/webauthn/#authenticator), such as a [roaming authenticator](https://w3c.github.io/webauthn/#roaming-authenticators) or an [authenticator](https://w3c.github.io/webauthn/#authenticator) that is capable of [multi-device credentials](https://w3c.github.io/webauthn/#multi-device-credential).