### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
@@ -23,7 +24,7 @@ jobs:
           - '2.5'
           - truffleruby
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
       - name: Block autosquash commits
         uses: xt0rted/block-autosquash-commits-action@v2
         with:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -179,8 +179,9 @@ def issue_certificate(
 end
 
 def fake_certificate_chain_validation_time(attestation_statement, time)
-  allow(attestation_statement).to receive(:attestation_root_certificates_store).and_wrap_original do |m, *args|
-    store = m.call(*args)
+  allow(attestation_statement).to receive(:attestation_root_certificates_store)
+    .and_wrap_original do |m, *_args, **kwargs|
+    store = m.call(**kwargs)
     store.time = time
     store
   end


### PR DESCRIPTION
Also updates the checkout action to v3.

Getting tests to run green on Ruby 3.2 required an update to the `fake_certificate_chain_validation_time` method, such that it separated out positional and keyword arguments and only passed the keyword arguments to the wrapped method.  Ruby 3.2 is somewhat more strict on the distinction between positional and keyword arguments.

This runs green on my fork.