### PR TITLE
Rename reserved bits 2 and 3 into `backup_eligibility` and `backup_state`

### DIFF
--- a/lib/webauthn/authenticator_data.rb
+++ b/lib/webauthn/authenticator_data.rb
@@ -20,8 +20,8 @@ module WebAuthn
       bit1 :extension_data_included
       bit1 :attested_credential_data_included
       bit1 :reserved_for_future_use_4
-      bit1 :reserved_for_future_use_3
-      bit1 :reserved_for_future_use_2
+      bit1 :backup_state
+      bit1 :backup_eligibility
       bit1 :user_verified
       bit1 :reserved_for_future_use_1
       bit1 :user_present
@@ -60,6 +60,14 @@ module WebAuthn
 
     def attested_credential_data_included?
       flags.attested_credential_data_included == 1
+    end
+
+    def backup_eligibility
+      flags.backup_eligibility == 1
+    end
+
+    def backup_state
+      flags.backup_state == 1
     end
 
     def extension_data_included?

--- a/lib/webauthn/fake_authenticator/authenticator_data.rb
+++ b/lib/webauthn/fake_authenticator/authenticator_data.rb
@@ -47,8 +47,8 @@ module WebAuthn
             reserved_for_future_use_bit,
             bit(:user_verified),
             reserved_for_future_use_bit,
-            reserved_for_future_use_bit,
-            reserved_for_future_use_bit,
+            bit(:backup_state),
+            bit(:backup_eligibility),
             attested_credential_data_included_bit,
             extension_data_included_bit
           ].join


### PR DESCRIPTION
These bits are now assigned in the WebAuthn spec: https://w3c.github.io/webauthn/#authenticator-data
The spec also contains additional information about the semantics of these bits, including one currently forbidden combination.

For now, this change only implements the bits without offering or using any interpretation of them, or of their combined values.