### PR TITLE
feat: Apple App Attestation proof-of-concept.

### DIFF
--- a/lib/webauthn/attestation_statement.rb
+++ b/lib/webauthn/attestation_statement.rb
@@ -3,6 +3,7 @@
 require "webauthn/attestation_statement/android_key"
 require "webauthn/attestation_statement/android_safetynet"
 require "webauthn/attestation_statement/apple"
+require "webauthn/attestation_statement/apple_app"
 require "webauthn/attestation_statement/fido_u2f"
 require "webauthn/attestation_statement/none"
 require "webauthn/attestation_statement/packed"
@@ -20,6 +21,7 @@ module WebAuthn
     ATTESTATION_FORMAT_ANDROID_KEY = "android-key"
     ATTESTATION_FORMAT_TPM = "tpm"
     ATTESTATION_FORMAT_APPLE = "apple"
+    ATTESTATION_FORMAT_APPLE_APP = "apple-appattest"
 
     FORMAT_TO_CLASS = {
       ATTESTATION_FORMAT_NONE => WebAuthn::AttestationStatement::None,
@@ -28,7 +30,8 @@ module WebAuthn
       ATTESTATION_FORMAT_ANDROID_SAFETYNET => WebAuthn::AttestationStatement::AndroidSafetynet,
       ATTESTATION_FORMAT_ANDROID_KEY => WebAuthn::AttestationStatement::AndroidKey,
       ATTESTATION_FORMAT_TPM => WebAuthn::AttestationStatement::TPM,
-      ATTESTATION_FORMAT_APPLE => WebAuthn::AttestationStatement::Apple
+      ATTESTATION_FORMAT_APPLE => WebAuthn::AttestationStatement::Apple,
+      ATTESTATION_FORMAT_APPLE_APP => WebAuthn::AttestationStatement::AppleApp
     }.freeze
 
     def self.from(format, statement, relying_party: WebAuthn.configuration.relying_party)

--- a/lib/webauthn/attestation_statement/apple_app.rb
+++ b/lib/webauthn/attestation_statement/apple_app.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "openssl"
+require "webauthn/attestation_statement/base"
+
+module WebAuthn
+  module AttestationStatement
+    class AppleApp < Base
+      # Source: https://www.apple.com/certificateauthority/private/
+      ROOT_CERTIFICATE =
+        OpenSSL::X509::Certificate.new(<<~PEM)
+          -----BEGIN CERTIFICATE-----
+          MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw
+          JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK
+          QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa
+          Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv
+          biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y
+          bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh
+          NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9au
+          Yen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/
+          MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYw
+          CgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn
+          53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijV
+          oyFraWVIyd/dganmrduC1bmTBGwD
+          -----END CERTIFICATE-----
+        PEM
+
+      NONCE_EXTENSION_OID = "1.2.840.113635.100.8.2"
+
+      # appattest followed by seven 0x00 bytes
+      AAGUID_PRODUCTION = "61707061-7474-6573-7400-000000000000"
+
+      # appattestdevelop
+      AAGUID_DEVELOPMENT = "61707061-7474-6573-7464-6576656c6f70"
+
+      ## https://developer.apple.com/documentation/devicecheck/validating_apps_that_connect_to_your_server
+      def valid?(authenticator_data, client_data_hash)
+        ## 1. Verify that the x5c array contains the intermediate and
+        ## leaf certificates for App Attest, starting from the
+        ## credential certificate in the first data buffer in the
+        ## array (credcert). Verify the validity of the certificates
+        ## using Apple’s App Attest root certificate.
+        trustworthy? &&
+          # steps 2, 3, 4
+          valid_nonce?(authenticator_data, client_data_hash) &&
+          ## step 5. Create the SHA256 hash of the public key in credCert,
+          ## and verify that it matches the key identifier from your
+          ## app.
+          matching_public_key?(authenticator_data) &&
+          ## 6. Compute the SHA256 hash of your app’s App ID, and
+          ## verify that it’s the same as the authenticator data’s RP
+          ## ID hash.
+          matching_rp_id?(authenticator_data) &&
+          ## 7. Verify that the authenticator data’s counter field equals 0.
+          counter_zero?(authenticator_data) &&
+          ## 8. Verify that the authenticator data’s aaguid field is
+          ## either appattestdevelop if operating in the development
+          ## environment, or appattest followed by seven 0x00 bytes if
+          ## operating in the production environment.
+          valid_aaguid?(authenticator_data) &&
+          ## 9. Verify that the authenticator data’s credentialId field is the same as the key identifier.
+          valid_credential_id?(authenticator_data) &&
+          [attestation_type, attestation_trust_path]
+      end
+
+      private
+
+      ## 2. Create clientDataHash as the SHA256 hash of the one-time
+      ## challenge your server sends to your app before performing the
+      ## attestation, and append that hash to the end of the
+      ## authenticator data (authData from the decoded object).
+
+      ## 3. Generate a new SHA256 hash of the composite item to create nonce
+
+      ## 4. Obtain the value of the credCert extension with OID
+      ## 1.2.840.113635.100.8.2, which is a DER-encoded ASN.1
+      ## sequence. Decode the sequence and extract the single octet
+      ## string that it contains. Verify that the string equals nonce.
+      def valid_nonce?(authenticator_data, client_data_hash)
+        extension = cred_cert.find_extension(NONCE_EXTENSION_OID)
+
+        sequence = OpenSSL::ASN1.decode(extension.value_der)
+
+        sequence.tag == OpenSSL::ASN1::SEQUENCE &&
+          sequence.value.size == 1 &&
+          sequence.value[0].value[0].value ==
+            OpenSSL::Digest::SHA256.digest(authenticator_data.data + client_data_hash)
+      end
+
+      def matching_rp_id?(authenticator_data)
+        authenticator_data.rp_id_hash == OpenSSL::Digest::SHA256.digest(WebAuthn.configuration.rp_id)
+      end
+
+      def counter_zero?(authenticator_data)
+        authenticator_data.sign_count.zero?
+      end
+
+      def valid_aaguid?(authenticator_data)
+        expected_aaguid =
+          WebAuthn.configuration.development_mode ? AAGUID_DEVELOPMENT : AAGUID_PRODUCTION
+
+        authenticator_data.aaguid == expected_aaguid
+      end
+
+      def valid_credential_id?(_authenticator_data)
+        # TODO: how to implement this when we don't have access to the key_id a this stage?
+
+        # authenticator_data.credential.id == key_id
+
+        true
+      end
+
+      # https://www.w3.org/TR/webauthn/#sctn-attestation-types
+      def attestation_type
+        # used by Android SafetyNet and webauthn4j AppleApp implementation
+        WebAuthn::AttestationStatement::ATTESTATION_TYPE_BASIC
+      end
+
+      def cred_cert
+        attestation_certificate
+      end
+
+      def default_root_certificates
+        [ROOT_CERTIFICATE]
+      end
+    end
+  end
+end

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -35,7 +35,9 @@ module WebAuthn
                    :encoder,
                    :encoder=,
                    :legacy_u2f_appid,
-                   :legacy_u2f_appid=
+                   :legacy_u2f_appid=,
+                   :development_mode,
+                   :development_mode=
 
     attr_reader :relying_party
 

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -26,7 +26,8 @@ module WebAuthn
       silent_authentication: false,
       acceptable_attestation_types: ['None', 'Self', 'Basic', 'AttCA', 'Basic_or_AttCA', 'AnonCA'],
       attestation_root_certificates_finders: [],
-      legacy_u2f_appid: nil
+      legacy_u2f_appid: nil,
+      development_mode: false
     )
       @algorithms = algorithms
       @encoding = encoding
@@ -38,6 +39,7 @@ module WebAuthn
       @silent_authentication = silent_authentication
       @acceptable_attestation_types = acceptable_attestation_types
       @legacy_u2f_appid = legacy_u2f_appid
+      @development_mode = development_mode
       self.attestation_root_certificates_finders = attestation_root_certificates_finders
     end
 
@@ -50,7 +52,8 @@ module WebAuthn
                   :credential_options_timeout,
                   :silent_authentication,
                   :acceptable_attestation_types,
-                  :legacy_u2f_appid
+                  :legacy_u2f_appid,
+                  :development_mode
 
     attr_reader :attestation_root_certificates_finders
 

--- a/spec/webauthn/attestation_statement/apple_app_spec.rb
+++ b/spec/webauthn/attestation_statement/apple_app_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "openssl"
+require "webauthn/attestation_statement/apple_app"
+
+RSpec.describe "Apple App attestation" do
+  describe "#valid?" do
+    let(:credential_key) { create_ec_key }
+    let(:root_key) { create_ec_key }
+    let(:root_certificate) { create_root_certificate(root_key) }
+
+    let(:leaf_certificate) do
+      issue_certificate(root_certificate, root_key, attestation_key, name: "CN=TODO.apple.com")
+    end
+
+    let(:cred_cert) do
+      issue_certificate(root_certificate, root_key, credential_key, extensions: [cred_cert_extension])
+    end
+
+    let(:statement) { WebAuthn::AttestationStatement::AppleApp.new("x5c" => [cred_cert.to_der]) }
+
+    let(:apple_aaguid) { 'appattestdevelop' }
+    let(:development_mode) { true }
+    let(:sign_count) { 0 }
+    let(:authenticator_data_bytes) do
+      WebAuthn::FakeAuthenticator::AuthenticatorData.new(
+        rp_id_hash: OpenSSL::Digest.digest("SHA256", "RP"),
+        credential: { id: "0".b * 16, public_key: credential_key.public_key },
+        aaguid: apple_aaguid,
+        sign_count: sign_count
+      ).serialize
+    end
+
+    let(:authenticator_data) { WebAuthn::AuthenticatorData.deserialize(authenticator_data_bytes) }
+    let(:client_data_hash) { OpenSSL::Digest::SHA256.digest({}.to_json) }
+
+    let(:nonce) { Digest::SHA256.digest(authenticator_data.data + client_data_hash) }
+    let(:cred_cert_extension) do
+      OpenSSL::X509::Extension.new(
+        "1.2.840.113635.100.8.2",
+        OpenSSL::ASN1::Sequence.new(
+          [OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::OctetString.new(nonce)])]
+        )
+      )
+    end
+
+    before do
+      WebAuthn.configure do |config|
+        config.rp_id = 'RP'
+        config.development_mode = development_mode
+      end
+    end
+
+    around do |example|
+      silence_warnings do
+        original_apple_certificate = WebAuthn::AttestationStatement::AppleApp::ROOT_CERTIFICATE
+        WebAuthn::AttestationStatement::AppleApp::ROOT_CERTIFICATE = root_certificate
+        example.run
+        WebAuthn::AttestationStatement::AppleApp::ROOT_CERTIFICATE = original_apple_certificate
+      end
+    end
+
+    it "works if everything's fine" do
+      expect(statement.valid?(authenticator_data, client_data_hash)).to be_truthy
+    end
+
+    context "when production mode" do
+      let(:development_mode) { false }
+      let(:apple_aaguid) { "appattest\x00\x00\x00\x00\x00\x00\x00" }
+
+      it { expect(statement.valid?(authenticator_data, client_data_hash)).to be_truthy }
+    end
+
+    context "when sign_count is not zero" do
+      let(:sign_count) { 1 }
+
+      it "fails" do
+        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+      end
+    end
+
+    context "when nonce is invalid" do
+      let(:nonce) { Digest::SHA256.digest("Invalid") }
+
+      it "fails" do
+        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+      end
+    end
+
+    context "when the credential public key is invalid" do
+      let(:cred_cert) do
+        issue_certificate(root_certificate, root_key, create_ec_key, extensions: [cred_cert_extension])
+      end
+
+      it "fails" do
+        expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're looking into using this gem with Apple App attestation support, so I implemented the `app-appattest` format.  This is just a proof-of-concept code, we haven't tested it end-to-end, only manually.

The format and its validations are described [here](https://developer.apple.com/documentation/devicecheck/validating_apps_that_connect_to_your_server).

I would love to hear your feedback on this and also your opinion on two aspects that I had to deal with:

- Step 8 specifies: "Verify that the authenticator data’s aaguid field is either appattestdevelop if operating in the development environment, or appattest followed by seven 0x00 bytes if operating in the production environment."

However there is no way to distinguish between development and production environment -- I added a new configuration to the `RelyingParty` class for that.

- Step 9 specifies: "Verify that the authenticator data’s credentialId field is the same as the key identifier."

At this point in the class we have no access to the key identifier, so I have no idea how to support it -- any ideas?

Let me know your thoughts, thanks!