### PR TITLE
Remove upper version constraint on OpenSSL

### DIFF
--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bindata", "~> 2.4"
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "cose", "~> 1.1"
-  spec.add_dependency "openssl", ">= 2.2", "< 3.1"
+  spec.add_dependency "openssl", ">= 2.2"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
   spec.add_dependency "tpm-key_attestation", "~> 0.11.0"
 


### PR DESCRIPTION
This stops us from blocking newer Ruby or OpenSSL gem releases, for any future incompatibilities application authors can pin their OpenSSL version if need be.

Ref https://github.com/cedarcode/webauthn-ruby/issues/382