### PR TITLE
Fix circular require warning

### DIFF
--- a/lib/webauthn/credential.rb
+++ b/lib/webauthn/credential.rb
@@ -4,7 +4,6 @@ require "webauthn/public_key_credential/creation_options"
 require "webauthn/public_key_credential/request_options"
 require "webauthn/public_key_credential_with_assertion"
 require "webauthn/public_key_credential_with_attestation"
-require "webauthn/relying_party"
 
 module WebAuthn
   module Credential


### PR DESCRIPTION
This is a leftover from the [initial implementation](https://github.com/cedarcode/webauthn-ruby/pull/296/commits/80a5b5c292a2efd3d3ac4a1509f9e63c8c71e462#diff-4d6918aac61f2bd300984bf57e0b22f57876919c5eb3df532cd808dc065fa685) of supporting multiple relying party configurations, when the `relying_party` keyword argument in this file called `RelyingParty.new` instead of [using the Configuration object](https://github.com/cedarcode/webauthn-ruby/pull/296/commits/51ef18068684e72a3aefd6896000ef657d1d5f6d).

Closes #388