### PR TITLE
Set user_handle to nil for non-string data type

### DIFF
--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -14,7 +14,7 @@ module WebAuthn
       encoder = relying_party.encoder
 
       user_handle =
-        if response["userHandle"] && String === response["userHandle"]
+        if response["userHandle"] && response["userHandle"].is_a? String
           encoder.decode(response["userHandle"])
         end
 

--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -14,7 +14,7 @@ module WebAuthn
       encoder = relying_party.encoder
 
       user_handle =
-        if response["userHandle"]
+        if response["userHandle"] && String === response["userHandle"]
           encoder.decode(response["userHandle"])
         end
 


### PR DESCRIPTION
Current code expects `userHandle` value in string data type and it seems to work fine at least for desktop web browsers. I tested with Yubikey 5C NFC and it returns an empty string `''` for `userHandle`.
However, when I tested on mobile browsers (e.g., iOS Safari), it is returned with an empty object `{}` rather than an empty string, which causes an error in the backend code trying to encode a Hash object instead of a String object.

<img width="958" alt="Screenshot 2023-06-07 at 6 25 10 PM" src="https://github.com/cedarcode/webauthn-ruby/assets/14348482/11b216f8-31a5-44b9-a754-cd4deaf33fd8">

Because of this, I had to do a simple workaround temporarily in [one of my client application](https://github.com/elquimista/authenhub/commit/e1d0874e7aa22cd725884e2b74e7e10f96f686b3).

I don't know if this suggestion is a right approach but at least it fixes my problem. Please let me know if there is a better approach. I am not an expert when it comes to webauthn.