### PR TITLE
[FakeAuthenticator] Support EdDSA credential keys

### DIFF
--- a/lib/webauthn/fake_authenticator.rb
+++ b/lib/webauthn/fake_authenticator.rb
@@ -85,7 +85,14 @@ module WebAuthn
           extensions: extensions
         ).serialize
 
-        signature = credential_key.sign("SHA256", authenticator_data + client_data_hash)
+        signature_digest_algorithm =
+          case credential_key
+          when OpenSSL::PKey::RSA, OpenSSL::PKey::EC
+            'SHA256'
+          when OpenSSL::PKey::PKey
+            nil
+          end
+        signature = credential_key.sign(signature_digest_algorithm, authenticator_data + client_data_hash)
         credential[:sign_count] += 1
 
         {

--- a/lib/webauthn/fake_authenticator/attestation_object.rb
+++ b/lib/webauthn/fake_authenticator/attestation_object.rb
@@ -61,7 +61,7 @@ module WebAuthn
           begin
             credential_data =
               if attested_credential_data
-                { id: credential_id, public_key: credential_key.public_key }
+                { id: credential_id, public_key: credential_public_key }
               end
 
             AuthenticatorData.new(
@@ -75,6 +75,15 @@ module WebAuthn
               extensions: extensions
             )
           end
+      end
+
+      def credential_public_key
+        case credential_key
+        when OpenSSL::PKey::RSA, OpenSSL::PKey::EC
+          credential_key.public_key
+        when OpenSSL::PKey::PKey
+          OpenSSL::PKey.read(credential_key.public_to_der)
+        end
       end
     end
   end

--- a/lib/webauthn/fake_authenticator/authenticator_data.rb
+++ b/lib/webauthn/fake_authenticator/authenticator_data.rb
@@ -140,7 +140,9 @@ module WebAuthn
 
           key = COSE::Key::EC2.from_pkey(credential[:public_key])
           key.alg = alg[key.crv]
-
+        when OpenSSL::PKey::PKey
+          key = COSE::Key::OKP.from_pkey(credential[:public_key])
+          key.alg = -8
         end
 
         key.serialize


### PR DESCRIPTION
Fixes #276.

The gem already supports EdDSA credential keys after https://github.com/cedarcode/cose-ruby/issues/48. This PR just updates `FakeAuthenticator`, `FakeAuthenticator::AttestationObject` and `FakeAuthenticator::AuthenticatorData` in order for them to be used with these keys.