### PR TITLE
Add base64 as an inlined implementation

### DIFF
--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
   spec.add_dependency "tpm-key_attestation", "~> 0.12.0"
 
+  spec.add_development_dependency "base64", ">= 0.1.0"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"
   spec.add_development_dependency "byebug", "~> 11.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This avoids a warning emitted by Ruby 3.3.0-preview2.

Fixes #401.

EDIT: inline the base64 implementation, and leave code comments that remind the reader about what they are seeing there.

Turn the base64 gem into a spec-supporting development dependency.