### PR TITLE
Remove unnecessary class `AttestationTrustworthinessVerificationError`

### DIFF
--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -12,7 +12,6 @@ require "webauthn/encoder"
 
 module WebAuthn
   class AttestationStatementVerificationError < VerificationError; end
-  class AttestationTrustworthinessVerificationError < VerificationError; end
   class AttestedCredentialVerificationError < VerificationError; end
 
   class AuthenticatorAttestationResponse < AuthenticatorResponse


### PR DESCRIPTION
Hi, first of all, thank you for creating this wonderful gem. This fix is ​​minor.
While reading the source code of this gem, I found a class that was probably unnecessary, so I opened this PR.

`AttestationTrustworthinessVerificationError` was used in the past, but I think it is no longer necessary due to the following PR.

https://github.com/cedarcode/webauthn-ruby/commit/72fa6fd894f75c07ddd42c1220e0da10d03e2b6e#diff-827ce4b0bc96a14830dfe8af8a60e263d595300ae9cd680719370147465c8db4L42

```bash
$ git grep attestation_trustworthiness => None
$ git grep AttestationTrustworthinessVerificationError => None
```

Therefore, I thought that I forgot to remove, but what do you think?