### PR TITLE
Suppressing unexpected error with `WebAuthn::PublicKeyCredentialWithAttestation#verify`

### DIFF
--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -5,11 +5,15 @@ require "webauthn/public_key_credential"
 
 module WebAuthn
   class PublicKeyCredentialWithAttestation < PublicKeyCredential
+    class InvalidChallengeError < Error; end
+
     def self.response_class
       WebAuthn::AuthenticatorAttestationResponse
     end
 
     def verify(challenge, user_verification: nil)
+      challenge.is_a?(String) || raise(InvalidChallengeError, "challenge must be a String. input challenge class: #{challenge.class}")
+
       super
 
       response.verify(encoder.decode(challenge), user_verification: user_verification)

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -12,7 +12,11 @@ module WebAuthn
     end
 
     def verify(challenge, user_verification: nil)
-      challenge.is_a?(String) || raise(InvalidChallengeError, "challenge must be a String. input challenge class: #{challenge.class}")
+      unless challenge.is_a?(String)
+        msg = "challenge must be a String. input challenge class: #{challenge.class}"
+
+        raise(InvalidChallengeError, msg)
+      end
 
       super
 

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -5,19 +5,11 @@ require "webauthn/public_key_credential"
 
 module WebAuthn
   class PublicKeyCredentialWithAttestation < PublicKeyCredential
-    class InvalidChallengeError < Error; end
-
     def self.response_class
       WebAuthn::AuthenticatorAttestationResponse
     end
 
     def verify(challenge, user_verification: nil)
-      unless challenge.is_a?(String)
-        msg = "challenge must be a String. input challenge class: #{challenge.class}"
-
-        raise(InvalidChallengeError, msg)
-      end
-
       super
 
       response.verify(encoder.decode(challenge), user_verification: user_verification)

--- a/spec/webauthn/public_key_credential_with_assertion_spec.rb
+++ b/spec/webauthn/public_key_credential_with_assertion_spec.rb
@@ -119,6 +119,18 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
       end
     end
 
+    context "when challenge class is invalid" do
+      it "raise error" do
+        expect do
+          public_key_credential.verify(
+            nil,
+            public_key: credential_public_key,
+            sign_count: credential_sign_count
+          )
+        end.to raise_error(WebAuthn::PublicKeyCredential::InvalidChallengeError)
+      end
+    end
+
     context "when challenge is invalid" do
       let(:challenge) { Base64.urlsafe_encode64("another challenge") }
 

--- a/spec/webauthn/public_key_credential_with_attestation_spec.rb
+++ b/spec/webauthn/public_key_credential_with_attestation_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "PublicKeyCredentialWithAttestation" do
       it "raise error" do
         expect {
           public_key_credential.verify(nil)
-        }.to raise_error(WebAuthn::PublicKeyCredentialWithAttestation::InvalidChallengeError)
+        }.to raise_error(WebAuthn::PublicKeyCredential::InvalidChallengeError)
       end
     end
 

--- a/spec/webauthn/public_key_credential_with_attestation_spec.rb
+++ b/spec/webauthn/public_key_credential_with_attestation_spec.rb
@@ -87,7 +87,15 @@ RSpec.describe "PublicKeyCredentialWithAttestation" do
       end
     end
 
-    context "when challenge is invalid" do
+    context "when challenge class is invalid" do
+      it "raise error" do
+        expect {
+          public_key_credential.verify(nil)
+        }.to raise_error(WebAuthn::PublicKeyCredentialWithAttestation::InvalidChallengeError)
+      end
+    end
+
+    context "when challenge value is invalid" do
       it "fails" do
         expect {
           public_key_credential.verify(Base64.urlsafe_encode64("another challenge"))


### PR DESCRIPTION
`WebAuthn::PublicKeyCredentialWithAttestation#verify` causes `NoMethodError` if `challenge` is `nil`. as below:

```ruby
undefined method `end_with?' for nil:NilClass

if !str.end_with?("=") && str.length % 4 != 0
           ^^^^^^^^^^
base64.rb:102:in `urlsafe_decode64'
```

Since `challenge` is assumed to refer to a value stored in temporary storage such as `session`, there may be cases where it does not exist by accident.
This change will make the error messages that occur when the above problem occurs more user-friendly and will help users of this library understand the errors.

