### PR TITLE
Add interface for accessing `transports`

### DIFF
--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -23,17 +23,19 @@ module WebAuthn
 
       new(
         attestation_object: encoder.decode(response["attestationObject"]),
+        transports: response["transports"],
         client_data_json: encoder.decode(response["clientDataJSON"]),
         relying_party: relying_party
       )
     end
 
-    attr_reader :attestation_type, :attestation_trust_path
+    attr_reader :attestation_type, :attestation_trust_path, :transports
 
-    def initialize(attestation_object:, **options)
+    def initialize(attestation_object:, transports: [], **options)
       super(**options)
 
       @attestation_object_bytes = attestation_object
+      @transports = transports
       @relying_party = relying_party
     end
 

--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -68,7 +68,8 @@ module WebAuthn
         "clientExtensionResults" => extensions,
         "response" => {
           "attestationObject" => encoder.encode(attestation_object),
-          "clientDataJSON" => encoder.encode(client_data_json)
+          "clientDataJSON" => encoder.encode(client_data_json),
+          "transports" => ["internal"],
         }
       }
     end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
     WebAuthn::AuthenticatorAttestationResponse.new(
       attestation_object: response["attestationObject"],
+      transports: response["transports"],
       client_data_json: response["clientDataJSON"]
     )
   end


### PR DESCRIPTION
## Summary

Step 23 of the [`Registering a New Credential` section of the WebAuthn Level 2 spec](https://www.w3.org/TR/webauthn-2/#sctn-registering-a-new-credential) states:

> It is RECOMMENDED to also:
>
>Associate the [credentialId](https://www.w3.org/TR/webauthn-2/#credentialid) with the transport hints returned by calling credential.[response](https://www.w3.org/TR/webauthn-2/#dom-publickeycredential-response).[getTransports()](https://www.w3.org/TR/webauthn-2/#dom-authenticatorattestationresponse-gettransports). This value SHOULD NOT be modified before or after storing it. It is RECOMMENDED to use this value to populate the [transports](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialdescriptor-transports) of the [allowCredentials](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-allowcredentials) option in future [get()](https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get) calls to help the [client](https://www.w3.org/TR/webauthn-2/#client) know how to find a suitable [authenticator](https://www.w3.org/TR/webauthn-2/#authenticator).

This PR adds the necessary interface for relying parties to easily access to this value, by doing:

```ruby
WebAuthn::Credential.from_create(credential_params).response.transports # => ["internal"]
```