### PR TITLE
Fix tests failing with OpenSSL v3

### DIFF
--- a/spec/webauthn/attestation_statement/packed_spec.rb
+++ b/spec/webauthn/attestation_statement/packed_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe "Packed attestation" do
       let(:algorithm) { -7 }
       let(:attestation_key) { create_ec_key }
       let(:signature) { attestation_key.sign("SHA256", to_be_signed) }
-      let(:attestation_certificate_version) { 2 }
       let(:attestation_certificate_subject) { "/C=UY/O=ACME/OU=Authenticator Attestation/CN=CN" }
       let(:attestation_certificate_basic_constraints) { "CA:FALSE" }
       let(:attestation_certificate_start_time) { Time.now - 1 }
@@ -103,7 +102,7 @@ RSpec.describe "Packed attestation" do
           root_certificate,
           root_key,
           attestation_key,
-          version: attestation_certificate_version,
+          version: 2,
           name: attestation_certificate_subject,
           not_before: attestation_certificate_start_time,
           not_after: attestation_certificate_end_time,
@@ -187,7 +186,9 @@ RSpec.describe "Packed attestation" do
 
       context "when the attestation certificate doesn't meet requirements" do
         context "because version is invalid" do
-          let(:attestation_certificate_version) { 1 }
+          before do
+            attestation_certificate.version = 1
+          end
 
           it "fails" do
             expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy

--- a/spec/webauthn/attestation_statement/tpm_spec.rb
+++ b/spec/webauthn/attestation_statement/tpm_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "TPM attestation statement" do
           root_certificate,
           root_key,
           aik,
-          version: aik_certificate_version,
+          version: 2,
           name: aik_certificate_subject,
           not_before: aik_certificate_start_time,
           not_after: aik_certificate_end_time,
@@ -49,7 +49,6 @@ RSpec.describe "TPM attestation statement" do
       end
 
       let(:aik) { create_rsa_key }
-      let(:aik_certificate_version) { 2 }
       let(:aik_certificate_subject) { "" }
       let(:aik_certificate_basic_constraints) { "CA:FALSE" }
       let(:aik_certificate_extended_key_usage) { ::TPM::AIKCertificate::OID_TCG_KP_AIK_CERTIFICATE }
@@ -361,7 +360,9 @@ RSpec.describe "TPM attestation statement" do
 
       context "when the AIK certificate doesn't meet requirements" do
         context "because version is invalid" do
-          let(:aik_certificate_version) { 1 }
+          before do
+            aik_certificate.version = 1
+          end
 
           it "returns false" do
             expect(statement.valid?(authenticator_data, client_data_hash)).to be_falsy


### PR DESCRIPTION
Fixes #417.

Some tests fail when using OpenSSL v3. The issue is that, for testing the `valid?` method for attestation statements, we set up a certificate to have an invalid version (version is 1 initially) and expect the attestation statement to not be valid. But when setting up the certificate we have to sign it which, in newer versions of OpenSSL, updates the version to a valid one (version changes to be 2), thus causing the expectation to not be met and therefore the spec to fail.

This PR fixes the issue by changing the version after the certificate has been signed.