### PR TITLE
Allow specifying expected origin and rp_id when verifying public key credentials

### DIFF
--- a/lib/webauthn/public_key_credential_with_assertion.rb
+++ b/lib/webauthn/public_key_credential_with_assertion.rb
@@ -9,15 +9,16 @@ module WebAuthn
       WebAuthn::AuthenticatorAssertionResponse
     end
 
-    def verify(challenge, public_key:, sign_count:, user_verification: nil)
+    def verify(challenge, expected_origin: nil, public_key:, sign_count:, user_verification: nil, rp_id: (appid_extension_output ? appid : nil))
       super
 
       response.verify(
         encoder.decode(challenge),
+        expected_origin,
         public_key: encoder.decode(public_key),
         sign_count: sign_count,
         user_verification: user_verification,
-        rp_id: appid_extension_output ? appid : nil
+        rp_id: rp_id
       )
 
       true

--- a/lib/webauthn/public_key_credential_with_assertion.rb
+++ b/lib/webauthn/public_key_credential_with_assertion.rb
@@ -9,7 +9,8 @@ module WebAuthn
       WebAuthn::AuthenticatorAssertionResponse
     end
 
-    def verify(challenge, expected_origin: nil, public_key:, sign_count:, user_verification: nil, rp_id: (appid_extension_output ? appid : nil))
+    def verify(challenge, expected_origin: nil, public_key:, sign_count:,
+               user_verification: nil, rp_id: (appid_extension_output ? appid : nil))
       super
 
       response.verify(

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,10 +9,10 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, user_verification: nil)
+    def verify(challenge, expected_origin: nil, **kw)
       super
 
-      response.verify(encoder.decode(challenge), user_verification: user_verification)
+      response.verify(encoder.decode(challenge), expected_origin, **kw)
 
       true
     end

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,10 +9,10 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, expected_origin: nil, **kw)
+    def verify(challenge, expected_origin: nil, **keywords)
       super
 
-      response.verify(encoder.decode(challenge), expected_origin, **kw)
+      response.verify(encoder.decode(challenge), expected_origin, **keywords)
 
       true
     end

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,10 +9,11 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, expected_origin: nil, **keywords)
+    def verify(challenge, expected_origin: nil, user_verification: nil, rp_id: nil)
       super
 
-      response.verify(encoder.decode(challenge), expected_origin, **keywords)
+      response.verify(encoder.decode(challenge), expected_origin,
+                      user_verification: user_verification, rp_id: rp_id)
 
       true
     end


### PR DESCRIPTION
The lack of support for this is the reason Rodauth currently overrides internal WebAuthn methods. I would like Rodauth to stop doing that, by having WebAuthn officially support this.

I've tested this with the following patch to Rodauth:

```diff
diff --git a/lib/rodauth/features/webauthn.rb b/lib/rodauth/features/webauthn.rb
index 93d4530..4a67db5 100644
--- a/lib/rodauth/features/webauthn.rb
+++ b/lib/rodauth/features/webauthn.rb
@@ -244,6 +244,11 @@ module Rodauth
       end
     end

+    webauthn_fixed = WebAuthn::PublicKeyCredentialWithAttestation.instance_method(:verify).parameters.include?([:key, :expected_origin]) &&
+                     WebAuthn::PublicKeyCredentialWithAssertion.instance_method(:verify).parameters.include?([:key, :expected_origin])
+    define_method(:webauthn_fixed?){webauthn_fixed}
+    private :webauthn_fixed?
+
     def webauthn_auth_form_path
       webauthn_auth_path
     end
@@ -312,11 +317,12 @@ module Rodauth
     end

     def valid_new_webauthn_credential?(webauthn_credential)
+      kw = webauthn_fixed? ? {expected_origin: webauthn_origin, rp_id: webauthn_rp_id} : {}
       _override_webauthn_credential_response_verify(webauthn_credential)
       (challenge = param_or_nil(webauthn_setup_challenge_param)) &&
         (hmac = param_or_nil(webauthn_setup_challenge_hmac_param)) &&
         (timing_safe_eql?(compute_hmac(challenge), hmac) || (hmac_secret_rotation? && timing_safe_eql?(compute_old_hmac(challenge), hmac))) &&
-        webauthn_credential.verify(challenge)
+        webauthn_credential.verify(challenge, **kw)
     end

     def webauthn_credential_options_for_get
@@ -362,12 +368,17 @@ module Rodauth
     def valid_webauthn_credential_auth?(webauthn_credential)
       ds = webauthn_keys_ds.where(webauthn_keys_webauthn_id_column => webauthn_credential.id)
       pub_key, sign_count = ds.get([webauthn_keys_public_key_column, webauthn_keys_sign_count_column])
+      kw = {public_key: pub_key, sign_count: sign_count}
+      if webauthn_fixed?
+        kw[:expected_origin] = webauthn_origin
+        kw[:rp_id] = webauthn_rp_id
+      end

       _override_webauthn_credential_response_verify(webauthn_credential)
       (challenge = param_or_nil(webauthn_auth_challenge_param)) &&
         (hmac = param_or_nil(webauthn_auth_challenge_hmac_param)) &&
         (timing_safe_eql?(compute_hmac(challenge), hmac) || (hmac_secret_rotation? && timing_safe_eql?(compute_old_hmac(challenge), hmac))) &&
-        webauthn_credential.verify(challenge, public_key: pub_key, sign_count: sign_count) &&
+        webauthn_credential.verify(challenge, **kw) &&
         ds.update(
           webauthn_keys_sign_count_column => Integer(webauthn_credential.sign_count),
           webauthn_keys_last_use_column => Sequel::CURRENT_TIMESTAMP
@@ -409,6 +420,11 @@ module Rodauth

     private

+    if webauthn_fixed
+      def _override_webauthn_credential_response_verify(webauthn_credential)
+        # Nothing
+      end
+    else
       def _override_webauthn_credential_response_verify(webauthn_credential)
         # Hack around inability to override expected_origin and rp_id
         origin = webauthn_origin
@@ -418,6 +434,7 @@ module Rodauth
           super(expected_challenge, expected_origin || origin, **kw)
         end
       end
+    end

     def _two_factor_auth_links
       links = super
```