### PR TITLE
feat: allow multiple origins set per RelyingParty

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ For a Rails application this would go in `config/initializers/webauthn.rb`.
 WebAuthn.configure do |config|
   # This value needs to match `window.location.origin` evaluated by
   # the User Agent during registration and authentication ceremonies.
-  config.origin = "https://auth.example.com"
+  # Multiple origins can be used when needed. Using more than one will imply you MUST configure rp_id explicitely. If you need your credentials to be bound to a single origin but you have more than one tenant, please see [our Advanced Configuration section](https://github.com/cedarcode/webauthn-ruby/blob/master/docs/advanced_configuration.md) instead of adding multiple origins.
+  config.allowed_origins = ["https://auth.example.com"]
 
   # Relying Party name for display purposes
   config.rp_name = "Example Inc."

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -25,7 +25,8 @@ module WebAuthn
     end
 
     def verify(expected_challenge, expected_origin = nil, user_presence: nil, user_verification: nil, rp_id: nil)
-      expected_origin ||= relying_party.origin || raise("Unspecified expected origin")
+      expected_origin ||= relying_party.allowed_origins || raise("Unspecified expected origin")
+
       rp_id ||= relying_party.id
 
       verify_item(:type)
@@ -33,7 +34,11 @@ module WebAuthn
       verify_item(:challenge, expected_challenge)
       verify_item(:origin, expected_origin)
       verify_item(:authenticator_data)
-      verify_item(:rp_id, rp_id || rp_id_from_origin(expected_origin))
+
+      verify_item(
+        :rp_id,
+        rp_id || rp_id_from_origin(expected_origin)
+      )
 
       # Fallback to RP configuration unless user_presence is passed in explicitely
       if user_presence.nil? && !relying_party.silent_authentication || user_presence
@@ -84,10 +89,14 @@ module WebAuthn
     end
 
     def valid_origin?(expected_origin)
-      expected_origin && (client_data.origin == expected_origin)
+      return false unless expected_origin
+
+      expected_origin.include?(client_data.origin)
     end
 
     def valid_rp_id?(rp_id)
+      return false unless rp_id
+
       OpenSSL::Digest::SHA256.digest(rp_id) == authenticator_data.rp_id_hash
     end
 
@@ -106,7 +115,7 @@ module WebAuthn
     end
 
     def rp_id_from_origin(expected_origin)
-      URI.parse(expected_origin).host
+      URI.parse(expected_origin.first).host if expected_origin.size == 1
     end
 
     def type

--- a/lib/webauthn/client_data.rb
+++ b/lib/webauthn/client_data.rb
@@ -49,12 +49,10 @@ module WebAuthn
 
     def data
       @data ||=
-        begin
-          if client_data_json
-            JSON.parse(client_data_json)
-          else
-            raise ClientDataMissingError, "Client Data JSON is missing"
-          end
+        if client_data_json
+          JSON.parse(client_data_json)
+        else
+          raise ClientDataMissingError, "Client Data JSON is missing"
         end
     end
   end

--- a/lib/webauthn/configuration.rb
+++ b/lib/webauthn/configuration.rb
@@ -22,6 +22,8 @@ module WebAuthn
                    :encoding=,
                    :origin,
                    :origin=,
+                   :allowed_origins,
+                   :allowed_origins=,
                    :verify_attestation_statement,
                    :verify_attestation_statement=,
                    :credential_options_timeout,

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -9,15 +9,16 @@ module WebAuthn
   class RootCertificateFinderNotSupportedError < Error; end
 
   class RelyingParty
+    DEFAULT_ALGORITHMS = ["ES256", "PS256", "RS256"].compact.freeze
+
     def self.if_pss_supported(algorithm)
       OpenSSL::PKey::RSA.instance_methods.include?(:verify_pss) ? algorithm : nil
     end
 
-    DEFAULT_ALGORITHMS = ["ES256", "PS256", "RS256"].compact.freeze
-
     def initialize(
       algorithms: DEFAULT_ALGORITHMS.dup,
       encoding: WebAuthn::Encoder::STANDARD_ENCODING,
+      allowed_origins: nil,
       origin: nil,
       id: nil,
       name: nil,
@@ -30,7 +31,7 @@ module WebAuthn
     )
       @algorithms = algorithms
       @encoding = encoding
-      @origin = origin
+      @allowed_origins = allowed_origins
       @id = id
       @name = name
       @verify_attestation_statement = verify_attestation_statement
@@ -38,12 +39,13 @@ module WebAuthn
       @silent_authentication = silent_authentication
       @acceptable_attestation_types = acceptable_attestation_types
       @legacy_u2f_appid = legacy_u2f_appid
+      self.origin = origin
       self.attestation_root_certificates_finders = attestation_root_certificates_finders
     end
 
     attr_accessor :algorithms,
                   :encoding,
-                  :origin,
+                  :allowed_origins,
                   :id,
                   :name,
                   :verify_attestation_statement,
@@ -52,7 +54,7 @@ module WebAuthn
                   :acceptable_attestation_types,
                   :legacy_u2f_appid
 
-    attr_reader :attestation_root_certificates_finders
+    attr_reader :attestation_root_certificates_finders, :origin
 
     # This is the user-data encoder.
     # Used to decode user input and to encode data provided to the user.
@@ -117,6 +119,19 @@ module WebAuthn
       )
         block_given? ? [webauthn_credential, stored_credential] : webauthn_credential
       end
+    end
+
+    # DEPRECATED: This method will be removed in future.
+    def origin=(new_origin)
+      return if new_origin.nil?
+
+      warn(
+        "DEPRECATION WARNING: `WebAuthn.origin` is deprecated and will be removed in future. "\
+        "Please use `WebAuthn.allowed_origins` instead "\
+        "that also allows configuring multiple origins per Relying Party"
+      )
+
+      @allowed_origins ||= Array(new_origin) # rubocop:disable Naming/MemoizedInstanceVariableName
     end
   end
 end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -24,11 +24,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
   let(:public_key_credential) { client.create(challenge: original_challenge) }
 
-  before do
-    WebAuthn.configuration.origin = origin
-  end
-
-  context "when everything's in place" do
+  shared_examples "a valid attestation response" do
     it "verifies" do
       expect(attestation_response.verify(original_challenge)).to be_truthy
     end
@@ -36,16 +32,83 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     it "is valid" do
       expect(attestation_response.valid?(original_challenge)).to be_truthy
     end
+  end
 
-    # TODO: let FakeClient#create recieve a fixed credential
-    # https://github.com/cedarcode/webauthn-ruby/pull/302#discussion_r365338434
-    it "returns the credential" do
-      credential = attestation_response.credential
+  context "when everything's in place" do
+    context "when there is a single origin" do
+      before do
+        WebAuthn.configuration.origin = origin
+      end
 
-      expect(credential.id.class).to eq(BinData::String)
-      expect(credential.id.encoding).to eq(Encoding::BINARY)
-      expect(credential.public_key.class).to eq(String)
-      expect(credential.public_key.encoding).to be(Encoding::BINARY)
+      it_behaves_like "a valid attestation response"
+
+      # TODO: let FakeClient#create recieve a fixed credential
+      # https://github.com/cedarcode/webauthn-ruby/pull/302#discussion_r365338434
+      it "returns the credential" do
+        credential = attestation_response.credential
+
+        expect(credential.id.class).to eq(BinData::String)
+        expect(credential.id.encoding).to eq(Encoding::BINARY)
+        expect(credential.public_key.class).to eq(String)
+        expect(credential.public_key.encoding).to be(Encoding::BINARY)
+      end
+    end
+
+    context "when there are multiple allowed origins" do
+      let(:allowed_origins) do
+        [
+          fake_origin,
+          "android:apk-key-hash:blablablablablalblalla"
+        ]
+      end
+
+      before do
+        WebAuthn.configuration.allowed_origins = allowed_origins
+      end
+
+      context "when rp_id is set explicitly" do
+        before do
+          WebAuthn.configuration.rp_id = "localhost"
+        end
+
+        it_behaves_like "a valid attestation response"
+
+        # TODO: let FakeClient#create recieve a fixed credential
+        # https://github.com/cedarcode/webauthn-ruby/pull/302#discussion_r365338434
+        it "returns the credential" do
+          credential = attestation_response.credential
+
+          expect(credential.id.class).to eq(BinData::String)
+          expect(credential.id.encoding).to eq(Encoding::BINARY)
+          expect(credential.public_key.class).to eq(String)
+          expect(credential.public_key.encoding).to be(Encoding::BINARY)
+        end
+      end
+
+      context "when rp_id is not set explicitly" do
+        before do
+          WebAuthn.configuration.rp_id = nil
+        end
+
+        it "raises error" do
+          expect { attestation_response.verify(original_challenge) }.to raise_error(WebAuthn::RpIdVerificationError)
+        end
+
+        it "is not valid" do
+          expect(attestation_response.valid?(original_challenge)).to be_falsey
+        end
+
+        # TODO: let FakeClient#create recieve a fixed credential
+        # https://github.com/cedarcode/webauthn-ruby/pull/302#discussion_r365338434
+        it "returns the credential" do
+          credential = attestation_response.credential
+
+          expect(credential.id.class).to eq(BinData::String)
+          expect(credential.id.encoding).to eq(Encoding::BINARY)
+          expect(credential.public_key.class).to eq(String)
+          expect(credential.public_key.encoding).to be(Encoding::BINARY)
+        end
+      end
     end
   end
 
@@ -54,44 +117,76 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       Base64.strict_decode64(seeds[:security_key_direct][:credential_creation_options][:challenge])
     end
 
-    let(:origin) { "http://localhost:3000" }
+    context "when there is a single origin" do
+      let(:origin) { "http://localhost:3000" }
 
-    let(:attestation_response) do
-      response = seeds[:security_key_direct][:authenticator_attestation_response]
+      let(:attestation_response) do
+        response = seeds[:security_key_direct][:authenticator_attestation_response]
 
-      WebAuthn::AuthenticatorAttestationResponse.new(
-        attestation_object: Base64.strict_decode64(response[:attestation_object]),
-        client_data_json: Base64.strict_decode64(response[:client_data_json])
-      )
+        WebAuthn::AuthenticatorAttestationResponse.new(
+          attestation_object: Base64.strict_decode64(response[:attestation_object]),
+          client_data_json: Base64.strict_decode64(response[:client_data_json])
+        )
+      end
+
+      before do
+        WebAuthn.configuration.attestation_root_certificates_finders = finder_for('feitian_ft_fido_0200.pem')
+        WebAuthn.configuration.origin = origin
+      end
+
+      it_behaves_like "a valid attestation response"
+
+      it "returns attestation info" do
+        attestation_response.valid?(original_challenge)
+
+        expect(attestation_response.attestation_type).to eq("Basic_or_AttCA")
+        expect(attestation_response.attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
+      end
+
+      it "returns the credential" do
+        expect(attestation_response.credential.id.length).to be >= 16
+      end
+
+      it "returns the attestation certificate key" do
+        expect(attestation_response.attestation_certificate_key_id).to(
+          eq("f4b64a68c334e901b8e23c6e66e6866c31931f5d")
+        )
+      end
     end
 
-    before do
-      WebAuthn.configuration.attestation_root_certificates_finders = finder_for('feitian_ft_fido_0200.pem')
-    end
+    context "when there are multiple allowed origins" do
+      let(:allowed_origins) do
+        [
+          fake_origin,
+          "android:apk-key-hash:blablablablablalblalla"
+        ]
+      end
 
-    it "verifies" do
-      expect(attestation_response.verify(original_challenge)).to be_truthy
-    end
+      before do
+        WebAuthn.configuration.allowed_origins = allowed_origins
+      end
 
-    it "is valid" do
-      expect(attestation_response.valid?(original_challenge)).to eq(true)
-    end
+      context "when rp_id is set explicitly" do
+        before do
+          WebAuthn.configuration.rp_id = "localhost"
+        end
 
-    it "returns attestation info" do
-      attestation_response.valid?(original_challenge)
+        it_behaves_like "a valid attestation response"
+      end
 
-      expect(attestation_response.attestation_type).to eq("Basic_or_AttCA")
-      expect(attestation_response.attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
-    end
+      context "when rp_id is not set explicitly" do
+        before do
+          WebAuthn.configuration.rp_id = nil
+        end
 
-    it "returns the credential" do
-      expect(attestation_response.credential.id.length).to be >= 16
-    end
+        it "raises error" do
+          expect { attestation_response.verify(original_challenge) }.to raise_error(WebAuthn::RpIdVerificationError)
+        end
 
-    it "returns the attestation certificate key" do
-      expect(attestation_response.attestation_certificate_key_id).to(
-        eq("f4b64a68c334e901b8e23c6e66e6866c31931f5d")
-      )
+        it "is not valid" do
+          expect(attestation_response.valid?(original_challenge)).to be_falsey
+        end
+      end
     end
   end
 
@@ -113,13 +208,11 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       )
     end
 
-    it "verifies" do
-      expect(attestation_response.verify(original_challenge)).to be_truthy
+    before do
+      WebAuthn.configuration.origin = origin
     end
 
-    it "is valid" do
-      expect(attestation_response.valid?(original_challenge)).to eq(true)
-    end
+    it_behaves_like "a valid attestation response"
 
     it "returns attestation info" do
       attestation_response.valid?(original_challenge)
@@ -157,15 +250,10 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
     before do
       WebAuthn.configuration.attestation_root_certificates_finders = finder_for('yubico_u2f_root.pem')
+      WebAuthn.configuration.origin = origin
     end
 
-    it "verifies" do
-      expect(attestation_response.verify(original_challenge)).to be_truthy
-    end
-
-    it "is valid" do
-      expect(attestation_response.valid?(original_challenge)).to eq(true)
-    end
+    it_behaves_like "a valid attestation response"
 
     it "returns attestation info" do
       attestation_response.valid?(original_challenge)
@@ -198,6 +286,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
+      WebAuthn.configuration.origin = origin
       WebAuthn.configure do |config|
         config.algorithms.concat(%w(RS1))
       end
@@ -216,15 +305,15 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     it "verifies" do
-      expect(attestation_response.verify(challenge, origin)).to be_truthy
+      expect(attestation_response.verify(challenge, WebAuthn.configuration.allowed_origins)).to be_truthy
     end
 
     it "is valid" do
-      expect(attestation_response.valid?(challenge, origin)).to eq(true)
+      expect(attestation_response.valid?(challenge, WebAuthn.configuration.allowed_origins)).to eq(true)
     end
 
     it "returns attestation info" do
-      attestation_response.valid?(challenge, origin)
+      attestation_response.valid?(challenge, WebAuthn.configuration.allowed_origins)
 
       expect(attestation_response.attestation_type).to eq("AttCA")
       expect(attestation_response.attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
@@ -258,16 +347,11 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
+      WebAuthn.configuration.origin = origin
       allow(attestation_response.attestation_statement).to receive(:time).and_return(time)
     end
 
-    it "verifies" do
-      expect(attestation_response.verify(original_challenge)).to be_truthy
-    end
-
-    it "is valid" do
-      expect(attestation_response.valid?(original_challenge)).to eq(true)
-    end
+    it_behaves_like "a valid attestation response"
 
     it "returns attestation info" do
       attestation_response.valid?(original_challenge)
@@ -286,8 +370,6 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   end
 
   context "when android-key attestation" do
-    let(:origin) { seeds[:android_key_direct][:origin] }
-
     let(:original_challenge) do
       Base64.urlsafe_decode64(seeds[:android_key_direct][:credential_creation_options][:challenge])
     end
@@ -305,27 +387,80 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       WebAuthn.configuration.attestation_root_certificates_finders = finder_for('android_key_root.pem')
     end
 
-    it "verifies" do
-      expect(attestation_response.verify(original_challenge)).to be_truthy
+    context "when there is a single origin" do
+      let(:origin) { seeds[:android_key_direct][:origin] }
+
+      before do
+        WebAuthn.configuration.origin = origin
+      end
+
+      it_behaves_like "a valid attestation response"
+
+      it "returns attestation info" do
+        attestation_response.valid?(original_challenge)
+
+        expect(attestation_response.attestation_type).to eq("Basic")
+        expect(attestation_response.attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
+      end
+
+      it "returns the credential" do
+        expect(attestation_response.credential.id.length).to be >= 16
+      end
+
+      it "returns the AAGUID" do
+        expect(attestation_response.aaguid).to eq("550e4b54-aa47-409f-9a95-1ab76c130131")
+      end
     end
 
-    it "is valid" do
-      expect(attestation_response.valid?(original_challenge)).to eq(true)
-    end
+    context "when there are multiple allowed origins" do
+      let(:allowed_origins) do
+        [
+          seeds[:android_key_direct][:origin],
+          "android:apk-key-hash:blablablablablalblalla",
+          "localhost"
+        ]
+      end
 
-    it "returns attestation info" do
-      attestation_response.valid?(original_challenge)
+      before do
+        WebAuthn.configuration.allowed_origins = allowed_origins
+      end
 
-      expect(attestation_response.attestation_type).to eq("Basic")
-      expect(attestation_response.attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
-    end
+      context "when rp_id is set explicitly" do
+        before do
+          WebAuthn.configuration.rp_id = "localhost"
+        end
 
-    it "returns the credential" do
-      expect(attestation_response.credential.id.length).to be >= 16
-    end
+        it_behaves_like "a valid attestation response"
 
-    it "returns the AAGUID" do
-      expect(attestation_response.aaguid).to eq("550e4b54-aa47-409f-9a95-1ab76c130131")
+        it "returns attestation info" do
+          attestation_response.valid?(original_challenge)
+
+          expect(attestation_response.attestation_type).to eq("Basic")
+          expect(attestation_response.attestation_trust_path).to all(be_kind_of(OpenSSL::X509::Certificate))
+        end
+
+        it "returns the credential" do
+          expect(attestation_response.credential.id.length).to be >= 16
+        end
+
+        it "returns the AAGUID" do
+          expect(attestation_response.aaguid).to eq("550e4b54-aa47-409f-9a95-1ab76c130131")
+        end
+      end
+
+      context "when rp_id is not set explicitly" do
+        before do
+          WebAuthn.configuration.rp_id = nil
+        end
+
+        it "raises error" do
+          expect { attestation_response.verify(original_challenge) }.to raise_error(WebAuthn::RpIdVerificationError)
+        end
+
+        it "is not valid" do
+          expect(attestation_response.valid?(original_challenge)).to be_falsey
+        end
+      end
     end
   end
 
@@ -346,18 +481,14 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
+      WebAuthn.configuration.origin = origin
+
       # Apple credential certificate expires after 3 days apparently.
       # Seed data was obtained 22nd Feb 2021, so we are simulating validation within that 3 day timeframe
       fake_certificate_chain_validation_time(attestation_response.attestation_statement, Time.parse("2021-02-23"))
     end
 
-    it "verifies" do
-      expect(attestation_response.verify(original_challenge)).to be_truthy
-    end
-
-    it "is valid" do
-      expect(attestation_response.valid?(original_challenge)).to eq(true)
-    end
+    it_behaves_like "a valid attestation response"
 
     it "returns attestation info" do
       attestation_response.valid?(original_challenge)
@@ -371,15 +502,21 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
   end
 
-  it "returns user-friendly error if no client data received" do
-    attestation_response = WebAuthn::AuthenticatorAttestationResponse.new(
-      attestation_object: "",
-      client_data_json: nil
-    )
+  context "when no client data received" do
+    before do
+      WebAuthn.configuration.origin = origin
+    end
 
-    expect {
-      attestation_response.valid?("", "")
-    }.to raise_exception(WebAuthn::ClientDataMissingError)
+    it "returns user-friendly error if no client data received" do
+      attestation_response = WebAuthn::AuthenticatorAttestationResponse.new(
+        attestation_object: "",
+        client_data_json: nil
+      )
+
+      expect {
+        attestation_response.valid?("", "")
+      }.to raise_exception(WebAuthn::ClientDataMissingError)
+    end
   end
 
   describe "origin validation" do
@@ -396,16 +533,14 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       )
     end
 
+    before do
+      WebAuthn.configuration.origin = origin
+    end
+
     context "matches the default one" do
       let(:actual_origin) { "http://localhost" }
 
-      it "verifies" do
-        expect(attestation_response.verify(original_challenge)).to be_truthy
-      end
-
-      it "is valid" do
-        expect(attestation_response.valid?(original_challenge)).to be_truthy
-      end
+      it_behaves_like "a valid attestation response"
     end
 
     context "doesn't match the default one" do
@@ -436,16 +571,14 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       )
     end
 
+    before do
+      WebAuthn.configuration.allowed_origins = [origin]
+    end
+
     context "matches the default one" do
       let(:rp_id) { "localhost" }
 
-      it "verifies" do
-        expect(attestation_response.verify(original_challenge)).to be_truthy
-      end
-
-      it "is valid" do
-        expect(attestation_response.valid?(original_challenge)).to be_truthy
-      end
+      it_behaves_like "a valid attestation response"
     end
 
     context "doesn't match the default one" do
@@ -469,28 +602,26 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
         WebAuthn.configuration.rp_id = rp_id
       end
 
-      it "verifies" do
-        expect(attestation_response.verify(original_challenge)).to be_truthy
-      end
-
-      it "is valid" do
-        expect(attestation_response.valid?(original_challenge)).to be_truthy
-      end
+      it_behaves_like "a valid attestation response"
     end
   end
 
   describe "tokenBinding validation" do
     let(:client) { WebAuthn::FakeClient.new(origin, token_binding: token_binding, encoding: false) }
 
+    before do
+      WebAuthn.configuration.origin = origin
+    end
+
     context "it has stuff" do
       let(:token_binding) { { status: "supported" } }
 
       it "verifies" do
-        expect(attestation_response.verify(original_challenge, origin)).to be_truthy
+        expect(attestation_response.verify(original_challenge, WebAuthn.configuration.allowed_origins)).to be_truthy
       end
 
       it "is valid" do
-        expect(attestation_response.valid?(original_challenge, origin)).to be_truthy
+        expect(attestation_response.valid?(original_challenge, WebAuthn.configuration.allowed_origins)).to be_truthy
       end
     end
 
@@ -499,12 +630,12 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
       it "doesn't verify" do
         expect {
-          attestation_response.verify(original_challenge, origin)
+          attestation_response.verify(original_challenge, WebAuthn.configuration.allowed_origins)
         }.to raise_exception(WebAuthn::TokenBindingVerificationError)
       end
 
       it "isn't valid" do
-        expect(attestation_response.valid?(original_challenge, origin)).to be_falsy
+        expect(attestation_response.valid?(original_challenge, WebAuthn.configuration.allowed_origins)).to be_falsy
       end
     end
   end
@@ -516,17 +647,17 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       context "when silent_authentication is not set" do
         it "doesn't verify if user presence is not set" do
           expect {
-            attestation_response.verify(original_challenge, origin)
+            attestation_response.verify(original_challenge, [origin])
           }.to raise_exception(WebAuthn::UserPresenceVerificationError)
         end
 
         it "verifies if user presence is not required" do
-          expect(attestation_response.verify(original_challenge, origin, user_presence: false)).to be_truthy
+          expect(attestation_response.verify(original_challenge, [origin], user_presence: false)).to be_truthy
         end
 
         it "doesn't verify if user presence is required" do
           expect {
-            attestation_response.verify(original_challenge, origin, user_presence: true)
+            attestation_response.verify(original_challenge, [origin], user_presence: true)
           }.to raise_exception(WebAuthn::UserPresenceVerificationError)
         end
       end
@@ -543,17 +674,17 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
         it "doesn't verify if user presence is not set" do
           expect {
-            attestation_response.verify(original_challenge, origin)
+            attestation_response.verify(original_challenge, [origin])
           }.to raise_exception(WebAuthn::UserPresenceVerificationError)
         end
 
         it "verifies if user presence is not required" do
-          expect(attestation_response.verify(original_challenge, origin, user_presence: false)).to be_truthy
+          expect(attestation_response.verify(original_challenge, [origin], user_presence: false)).to be_truthy
         end
 
         it "doesn't verify if user presence is required" do
           expect {
-            attestation_response.verify(original_challenge, origin, user_presence: true)
+            attestation_response.verify(original_challenge, [origin], user_presence: true)
           }.to raise_exception(WebAuthn::UserPresenceVerificationError)
         end
       end
@@ -569,16 +700,16 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
         end
 
         it "verifies if user presence is not set" do
-          expect(attestation_response.verify(original_challenge, origin)).to be_truthy
+          expect(attestation_response.verify(original_challenge, [origin])).to be_truthy
         end
 
         it "verifies if user presence is not required" do
-          expect(attestation_response.verify(original_challenge, origin, user_presence: false)).to be_truthy
+          expect(attestation_response.verify(original_challenge, [origin], user_presence: false)).to be_truthy
         end
 
         it "doesn't verify if user presence is required" do
           expect {
-            attestation_response.verify(original_challenge, origin, user_presence: true)
+            attestation_response.verify(original_challenge, [origin], user_presence: true)
           }.to raise_exception(WebAuthn::UserPresenceVerificationError)
         end
       end
@@ -586,24 +717,36 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   end
 
   describe "user verification" do
+    before do
+      WebAuthn.configuration.origin = origin
+    end
+
     context "when UV is not set" do
       let(:public_key_credential) { client.create(challenge: original_challenge, user_verified: false) }
 
       it "doesn't verify if user verification is required" do
         expect {
-          attestation_response.verify(original_challenge, origin, user_verification: true)
+          attestation_response.verify(
+            original_challenge,
+            WebAuthn.configuration.allowed_origins,
+            user_verification: true
+          )
         }.to raise_exception(WebAuthn::UserVerifiedVerificationError)
       end
     end
   end
 
   describe "attested credential data verification" do
+    before do
+      WebAuthn.configuration.origin = origin
+    end
+
     context "when AT is not set" do
       let(:public_key_credential) { client.create(challenge: original_challenge, attested_credential_data: false) }
 
       it "doesn't verify" do
         expect {
-          attestation_response.verify(original_challenge, origin)
+          attestation_response.verify(original_challenge, WebAuthn.configuration.allowed_origins)
         }.to raise_exception(WebAuthn::AttestedCredentialVerificationError)
       end
     end
@@ -615,7 +758,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
       it "doesn't verify" do
         expect {
-          attestation_response.verify(original_challenge, origin)
+          attestation_response.verify(original_challenge, WebAuthn.configuration.allowed_origins)
         }.to raise_exception(WebAuthn::AttestedCredentialVerificationError)
       end
     end
@@ -640,6 +783,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     before do
       attestation_response.attestation_statement.instance_variable_get(:@statement)["sig"] =
         "corrupted signature".b
+      WebAuthn.configuration.origin = origin
     end
 
     context "when verification is set to true" do
@@ -647,7 +791,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
         WebAuthn.configuration.verify_attestation_statement = true
       end
 
-      it "verifies the attestation statement" do
+      it "raises error" do
         expect { attestation_response.verify(original_challenge) }.to raise_error(OpenSSL::PKey::PKeyError)
       end
     end

--- a/spec/webauthn/relying_party_spec.rb
+++ b/spec/webauthn/relying_party_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "RelyingParty" do
 
   let(:admin_rp) do
     WebAuthn::RelyingParty.new(
-      origin: "https://admin.example.test",
+      allowed_origins: ["https://admin.example.test"],
       id: 'admin.example.test',
       name: 'Admin Application'
     )
@@ -136,7 +136,7 @@ RSpec.describe "RelyingParty" do
   context "without having any global configuration" do
     let(:consumer_rp) do
       WebAuthn::RelyingParty.new(
-        origin: "https://www.example.test",
+        allowed_origins: ["https://www.example.test"],
         id: 'example.test',
         name: 'Consumer Application'
       )
@@ -273,7 +273,7 @@ RSpec.describe "RelyingParty" do
 
   context "with a global configuration and a different relying party co-existing" do
     let(:global_configuration_client) do
-      WebAuthn::FakeClient.new(WebAuthn.configuration.origin, authenticator: authenticator)
+      WebAuthn::FakeClient.new(WebAuthn.configuration.allowed_origins[0], authenticator: authenticator)
     end
 
     before do
@@ -386,7 +386,7 @@ RSpec.describe "RelyingParty" do
 
   context "with only a global configuration" do
     let(:global_configuration_client) do
-      WebAuthn::FakeClient.new(WebAuthn.configuration.origin, authenticator: authenticator)
+      WebAuthn::FakeClient.new(WebAuthn.configuration.allowed_origins[0], authenticator: authenticator)
     end
 
     before do


### PR DESCRIPTION
As described in the issue https://github.com/cedarcode/webauthn-ruby/issues/428
when building a Relying Party that is supposed to be used by iOS and Android native clients, we need to be able to specify multiple allowed origins per RP (https://developer.android.com/identity/sign-in/credential-manager#verify-origin)
This is yet not supported by this library though is also part of standard specification https://w3c.github.io/webauthn/#sctn-validating-origin

Current workaround is to fallback to creating multiple RP abstractions per expected client platform (Android, iOS, etc) and select one of them based on `User-Agent` header (for example). That is of course troublesome and can actually be avoided. 

This PR allows a relying party to specify either string for origin or array of strings like in the example: 
 
```ruby
# config/initializers/webauthn.rb

WebAuthn.configure do |config|
  # This value needs to match `window.location.origin` evaluated by
  # the User Agent during registration and authentication ceremonies.
  # config.origin = "https://auth.example.com/"
  config.origin = [
    "https://auth.example.com/",
    "android:apk-key-hash:blablablablablalblalla"
  ]

  # Relying Party name for display purposes
  config.rp_name = "Example Inc."
  config.rp_id  = "example.com"
end
```
The only drawback of this approach is that in case an array is used for `config.origin`, - it's impossssible to "guess" relying party by origin (which maybe we should not even do?) thus having array there and no explicitly set `config.rp_id` would result in `RpIdVerificationError` which imo should be expected. 

Hope this PR makes sense. Please let me know should there be any change requests/questions 