### PR TITLE
passkey auto-upgrade need to skip user presence & verification check

### DIFF
--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -38,7 +38,7 @@ module WebAuthn
       @relying_party = relying_party
     end
 
-    def verify(expected_challenge, expected_origin = nil, user_verification: nil, rp_id: nil)
+    def verify(expected_challenge, expected_origin = nil, user_presence: true, user_verification: nil, rp_id: nil)
       super
 
       verify_item(:attested_credential)

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -24,7 +24,7 @@ module WebAuthn
       @relying_party = relying_party
     end
 
-    def verify(expected_challenge, expected_origin = nil, user_verification: nil, rp_id: nil)
+    def verify(expected_challenge, expected_origin = nil, user_presence: true, user_verification: nil, rp_id: nil)
       expected_origin ||= relying_party.origin || raise("Unspecified expected origin")
       rp_id ||= relying_party.id
 
@@ -35,7 +35,7 @@ module WebAuthn
       verify_item(:authenticator_data)
       verify_item(:rp_id, rp_id || rp_id_from_origin(expected_origin))
 
-      if !relying_party.silent_authentication
+      if !relying_party.silent_authentication && user_presence
         verify_item(:user_presence)
       end
 

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,10 +9,10 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, user_verification: nil)
+    def verify(challenge, user_presence: true, user_verification: nil)
       super
 
-      response.verify(encoder.decode(challenge), user_verification: user_verification)
+      response.verify(encoder.decode(challenge), user_presence: user_presence, user_verification: user_verification)
 
       true
     end

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -81,10 +81,10 @@ module WebAuthn
       )
     end
 
-    def verify_registration(raw_credential, challenge, user_verification: nil)
+    def verify_registration(raw_credential, challenge, user_presence: true, user_verification: nil)
       webauthn_credential = WebAuthn::Credential.from_create(raw_credential, relying_party: self)
 
-      if webauthn_credential.verify(challenge, user_verification: user_verification)
+      if webauthn_credential.verify(challenge, user_presence: user_presence, user_verification: user_verification)
         webauthn_credential
       end
     end

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -509,6 +509,22 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
   end
 
+  describe "user presence" do
+    context "when UP is not set" do
+      let(:public_key_credential) { client.create(challenge: original_challenge, user_present: false) }
+
+      it "verifies if user presence is not required" do
+        expect(attestation_response.verify(original_challenge, origin, user_presence: false)).to be_truthy
+      end
+
+      it "doesn't verify if user presence is required" do
+        expect {
+          attestation_response.verify(original_challenge, origin, user_presence: true)
+        }.to raise_exception(WebAuthn::UserPresenceVerificationError)
+      end
+    end
+  end
+
   describe "user verification" do
     context "when UV is not set" do
       let(:public_key_credential) { client.create(challenge: original_challenge, user_verified: false) }


### PR DESCRIPTION
new iOS / macOS now support passkey auto upgrade.
it doesn't support neither UV nor UP, and both flags are false by default.

to accept such attestations, those changes are needed.