### PR TITLE
Allow `user_presence` param in `AuthenticatorResponse#verify` to override `silent_authentication` config

### DIFF
--- a/lib/webauthn/authenticator_attestation_response.rb
+++ b/lib/webauthn/authenticator_attestation_response.rb
@@ -38,7 +38,7 @@ module WebAuthn
       @relying_party = relying_party
     end
 
-    def verify(expected_challenge, expected_origin = nil, user_presence: true, user_verification: nil, rp_id: nil)
+    def verify(expected_challenge, expected_origin = nil, user_presence: nil, user_verification: nil, rp_id: nil)
       super
 
       verify_item(:attested_credential)

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -35,8 +35,8 @@ module WebAuthn
       verify_item(:authenticator_data)
       verify_item(:rp_id, rp_id || rp_id_from_origin(expected_origin))
 
-      user_presence = !relying_party.silent_authentication if user_presence.nil?
-      if user_presence
+      # Fallback to RP configuration unless user_presence is passed in explicitely
+      if user_presence.nil? && !relying_party.silent_authentication || user_presence
         verify_item(:user_presence)
       end
 

--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -24,7 +24,7 @@ module WebAuthn
       @relying_party = relying_party
     end
 
-    def verify(expected_challenge, expected_origin = nil, user_presence: true, user_verification: nil, rp_id: nil)
+    def verify(expected_challenge, expected_origin = nil, user_presence: nil, user_verification: nil, rp_id: nil)
       expected_origin ||= relying_party.origin || raise("Unspecified expected origin")
       rp_id ||= relying_party.id
 
@@ -35,7 +35,8 @@ module WebAuthn
       verify_item(:authenticator_data)
       verify_item(:rp_id, rp_id || rp_id_from_origin(expected_origin))
 
-      if !relying_party.silent_authentication && user_presence
+      user_presence = !relying_party.silent_authentication if user_presence.nil?
+      if user_presence
         verify_item(:user_presence)
       end
 

--- a/lib/webauthn/public_key_credential_with_attestation.rb
+++ b/lib/webauthn/public_key_credential_with_attestation.rb
@@ -9,7 +9,7 @@ module WebAuthn
       WebAuthn::AuthenticatorAttestationResponse
     end
 
-    def verify(challenge, user_presence: true, user_verification: nil)
+    def verify(challenge, user_presence: nil, user_verification: nil)
       super
 
       response.verify(encoder.decode(challenge), user_presence: user_presence, user_verification: user_verification)

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -81,7 +81,7 @@ module WebAuthn
       )
     end
 
-    def verify_registration(raw_credential, challenge, user_presence: true, user_verification: nil)
+    def verify_registration(raw_credential, challenge, user_presence: nil, user_verification: nil)
       webauthn_credential = WebAuthn::Credential.from_create(raw_credential, relying_party: self)
 
       if webauthn_credential.verify(challenge, user_presence: user_presence, user_verification: user_verification)

--- a/spec/webauthn/public_key_credential_with_attestation_spec.rb
+++ b/spec/webauthn/public_key_credential_with_attestation_spec.rb
@@ -180,5 +180,31 @@ RSpec.describe "PublicKeyCredentialWithAttestation" do
         end
       end
     end
+
+    context "when user_presence" do
+      context "is not set" do
+        it "correcly delegates its value to the response" do
+          expect(attestation_response).to receive(:verify).with(anything, hash_including(user_presence: nil))
+
+          public_key_credential.verify(challenge)
+        end
+      end
+
+      context "is set to false" do
+        it "correcly delegates its value to the response" do
+          expect(attestation_response).to receive(:verify).with(anything, hash_including(user_presence: false))
+
+          public_key_credential.verify(challenge, user_presence: false)
+        end
+      end
+
+      context "is set to true" do
+        it "correcly delegates its value to the response" do
+          expect(attestation_response).to receive(:verify).with(anything, hash_including(user_presence: true))
+
+          public_key_credential.verify(challenge, user_presence: true)
+        end
+      end
+    end
   end
 end

--- a/spec/webauthn/relying_party_spec.rb
+++ b/spec/webauthn/relying_party_spec.rb
@@ -35,31 +35,36 @@ RSpec.describe "RelyingParty" do
       admin_fake_client.create(challenge: options.challenge, rp_id: admin_rp.id)
     end
 
-    it 'require user_presence by default' do
-      expect_any_instance_of(WebAuthn::PublicKeyCredentialWithAttestation).to receive(:verify).with(
-        options.challenge,
-        user_presence: true,
-        user_verification: nil
-      )
-      admin_rp.verify_registration(raw_credential, options.challenge)
-    end
+    context "when user_presence" do
+      let(:webauthn_credential_mock) { instance_double('WebAuthn::PublicKeyCredentialWithAttestation', verify: true) }
 
-    it 'can skip user_presence' do
-      expect_any_instance_of(WebAuthn::PublicKeyCredentialWithAttestation).to receive(:verify).with(
-        options.challenge,
-        user_presence: false,
-        user_verification: nil
-      )
-      admin_rp.verify_registration(raw_credential, options.challenge, user_presence: false)
-    end
+      before do
+        allow(WebAuthn::Credential).to receive(:from_create).and_return(webauthn_credential_mock)
+      end
 
-    it 'can require user_verification' do
-      expect_any_instance_of(WebAuthn::PublicKeyCredentialWithAttestation).to receive(:verify).with(
-        options.challenge,
-        user_presence: true,
-        user_verification: true
-      )
-      admin_rp.verify_registration(raw_credential, options.challenge, user_verification: true)
+      context "is not set" do
+        it "correcly delegates its value to the response" do
+          expect(webauthn_credential_mock).to receive(:verify).with(anything, hash_including(user_presence: nil))
+
+          admin_rp.verify_registration(raw_credential, options.challenge)
+        end
+      end
+
+      context "is set to false" do
+        it "correcly delegates its value to the response" do
+          expect(webauthn_credential_mock).to receive(:verify).with(anything, hash_including(user_presence: false))
+
+          admin_rp.verify_registration(raw_credential, options.challenge, user_presence: false)
+        end
+      end
+
+      context "is set to true" do
+        it "correcly delegates its value to the response" do
+          expect(webauthn_credential_mock).to receive(:verify).with(anything, hash_including(user_presence: true))
+
+          admin_rp.verify_registration(raw_credential, options.challenge, user_presence: true)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Motivation

After #432 was merged it was possible to call `AuthenticatorResponse#verify` with `user_presence` being `true` while having enabled `silent_authentication` for the Relying Party and the method would not verify user presence which would be confusing for users.

## Details

This PR changes this behavior so that the `user_presence` param, when passed, will always override the `silent_authentication` config.