### PR TITLE
Allow to skip `user_presence` check for assertions

### DIFF
--- a/lib/webauthn/authenticator_assertion_response.rb
+++ b/lib/webauthn/authenticator_assertion_response.rb
@@ -37,8 +37,22 @@ module WebAuthn
       @user_handle = user_handle
     end
 
-    def verify(expected_challenge, expected_origin = nil, public_key:, sign_count:, user_verification: nil, rp_id: nil)
-      super(expected_challenge, expected_origin, user_verification: user_verification, rp_id: rp_id)
+    def verify(
+      expected_challenge,
+      expected_origin = nil,
+      public_key:,
+      sign_count:,
+      user_presence: nil,
+      user_verification: nil,
+      rp_id: nil
+    )
+      super(
+        expected_challenge,
+        expected_origin,
+        user_presence: user_presence,
+        user_verification: user_verification,
+        rp_id: rp_id
+      )
       verify_item(:signature, WebAuthn::PublicKey.deserialize(public_key))
       verify_item(:sign_count, sign_count)
 

--- a/lib/webauthn/public_key_credential_with_assertion.rb
+++ b/lib/webauthn/public_key_credential_with_assertion.rb
@@ -9,13 +9,14 @@ module WebAuthn
       WebAuthn::AuthenticatorAssertionResponse
     end
 
-    def verify(challenge, public_key:, sign_count:, user_verification: nil)
+    def verify(challenge, public_key:, sign_count:, user_presence: nil, user_verification: nil)
       super
 
       response.verify(
         encoder.decode(challenge),
         public_key: encoder.decode(public_key),
         sign_count: sign_count,
+        user_presence: user_presence,
         user_verification: user_verification,
         rp_id: appid_extension_output ? appid : nil
       )

--- a/lib/webauthn/relying_party.rb
+++ b/lib/webauthn/relying_party.rb
@@ -99,6 +99,7 @@ module WebAuthn
     def verify_authentication(
       raw_credential,
       challenge,
+      user_presence: nil,
       user_verification: nil,
       public_key: nil,
       sign_count: nil
@@ -111,6 +112,7 @@ module WebAuthn
         challenge,
         public_key: public_key || stored_credential.public_key,
         sign_count: sign_count || stored_credential.sign_count,
+        user_presence: user_presence,
         user_verification: user_verification
       )
         block_given? ? [webauthn_credential, stored_credential] : webauthn_credential

--- a/spec/webauthn/authenticator_assertion_response_spec.rb
+++ b/spec/webauthn/authenticator_assertion_response_spec.rb
@@ -103,19 +103,217 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
   end
 
   describe "user present validation" do
-    let(:assertion) { client.get(challenge: original_challenge, user_present: false, user_verified: false) }
+    context "when user presence flag is off" do
+      let(:assertion) { client.get(challenge: original_challenge, user_present: false, user_verified: false) }
 
-    context "if user flags are off" do
-      it "doesn't verify" do
-        expect {
-          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
-        }.to raise_exception(WebAuthn::UserPresenceVerificationError)
+      context "when silent_authentication is not set" do
+        context 'when user presence is not set' do
+          it "doesn't verify" do
+            expect {
+              assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
+            }.to raise_exception(WebAuthn::UserPresenceVerificationError)
+          end
+
+          it "is invalid" do
+            expect(
+              assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+            ).to be_falsy
+          end
+        end
+
+        context 'when user presence is not required' do
+          it "verifies if user presence is not required" do
+            expect(
+              assertion_response.verify(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: false
+              )
+            ).to be_truthy
+          end
+
+          it "is valid" do
+            expect(
+              assertion_response.valid?(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: false
+              )
+            ).to be_truthy
+          end
+        end
+
+        context 'when user presence is required' do
+          it "doesn't verify" do
+            expect {
+              assertion_response.verify(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: true
+              )
+            }.to raise_exception(WebAuthn::UserPresenceVerificationError)
+          end
+
+          it "is invalid" do
+            expect(
+              assertion_response.valid?(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: true
+              )
+            ).to be_falsy
+          end
+        end
       end
 
-      it "is invalid" do
-        expect(
-          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
-        ).to be_falsy
+      context "when silent_authentication is disabled" do
+        around do |ex|
+          old_value = WebAuthn.configuration.silent_authentication
+          WebAuthn.configuration.silent_authentication = false
+
+          ex.run
+
+          WebAuthn.configuration.silent_authentication = old_value
+        end
+
+        context 'when user presence is not set' do
+          it "doesn't verify" do
+            expect {
+              assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
+            }.to raise_exception(WebAuthn::UserPresenceVerificationError)
+          end
+
+          it "is invalid" do
+            expect(
+              assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+            ).to be_falsy
+          end
+        end
+
+        context 'when user presence is not required' do
+          it "verifies if user presence is not required" do
+            expect(
+              assertion_response.verify(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: false
+              )
+            ).to be_truthy
+          end
+
+          it "is valid" do
+            expect(
+              assertion_response.valid?(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: false
+              )
+            ).to be_truthy
+          end
+        end
+
+        context 'when user presence is required' do
+          it "doesn't verify" do
+            expect {
+              assertion_response.verify(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: true
+              )
+            }.to raise_exception(WebAuthn::UserPresenceVerificationError)
+          end
+
+          it "is invalid" do
+            expect(
+              assertion_response.valid?(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: true
+              )
+            ).to be_falsy
+          end
+        end
+      end
+
+      context "when silent_authentication is enabled" do
+        around do |ex|
+          old_value = WebAuthn.configuration.silent_authentication
+          WebAuthn.configuration.silent_authentication = true
+
+          ex.run
+
+          WebAuthn.configuration.silent_authentication = old_value
+        end
+
+        context 'when user presence is not set' do
+          it "verifies if user presence is not required" do
+            expect(
+              assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
+            ).to be_truthy
+          end
+
+          it "is valid" do
+            expect(
+              assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
+            ).to be_truthy
+          end
+        end
+
+        context 'when user presence is not required' do
+          it "verifies if user presence is not required" do
+            expect(
+              assertion_response.verify(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: false
+              )
+            ).to be_truthy
+          end
+
+          it "is valid" do
+            expect(
+              assertion_response.valid?(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: false
+              )
+            ).to be_truthy
+          end
+        end
+
+        context 'when user presence is required' do
+          it "doesn't verify" do
+            expect {
+              assertion_response.verify(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: true
+              )
+            }.to raise_exception(WebAuthn::UserPresenceVerificationError)
+          end
+
+          it "is invalid" do
+            expect(
+              assertion_response.valid?(
+                original_challenge,
+                public_key: credential_public_key,
+                sign_count: 0,
+                user_presence: true
+              )
+            ).to be_falsy
+          end
+        end
       end
     end
   end

--- a/spec/webauthn/public_key_credential_with_assertion_spec.rb
+++ b/spec/webauthn/public_key_credential_with_assertion_spec.rb
@@ -352,5 +352,41 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
         end
       end
     end
+
+    context "when user_presence" do
+      context "is not set" do
+        it "correcly delegates its value to the response" do
+          expect(assertion_response).to receive(:verify).with(anything, hash_including(user_presence: nil))
+
+          public_key_credential.verify(challenge, public_key: credential_public_key, sign_count: credential_sign_count)
+        end
+      end
+
+      context "is set to false" do
+        it "correcly delegates its value to the response" do
+          expect(assertion_response).to receive(:verify).with(anything, hash_including(user_presence: false))
+
+          public_key_credential.verify(
+            challenge,
+            public_key: credential_public_key,
+            sign_count: credential_sign_count,
+            user_presence: false
+          )
+        end
+      end
+
+      context "is set to true" do
+        it "correcly delegates its value to the response" do
+          expect(assertion_response).to receive(:verify).with(anything, hash_including(user_presence: true))
+
+          public_key_credential.verify(
+            challenge,
+            public_key: credential_public_key,
+            sign_count: credential_sign_count,
+            user_presence: true
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Similar to #432 but for assertions.

This is just for completeness: as we have a Relying Party scoped config for skipping `user_presence` in `silent_authentication` and a param for skipping it when calling `verify` for attestations, it should be possible to also skip the `user_presence` check for assertions with a param instead of only with the global config.