### PR TITLE
Remove awrence dependency and test against 3.4 with frozen strings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@
 
 name: build
 
-on:  
+on:
   push:
     branches: [master]
   pull_request:
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.4.0-preview2'
           - '3.3'
           - '3.2'
           - '3.1'
@@ -35,3 +36,5 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rake
+      env:
+        RUBYOPT: ${{ startsWith(matrix.ruby, '3.4') && '--enable=frozen-string-literal' || '' }}

--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "webauthn/camelize"
 require "webauthn/configuration"
 require "webauthn/credential"
 require "webauthn/credential_creation_options"

--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "webauthn/camelize"
+require "webauthn/camelize_helper"
 require "webauthn/configuration"
 require "webauthn/credential"
 require "webauthn/credential_creation_options"

--- a/lib/webauthn/camelize.rb
+++ b/lib/webauthn/camelize.rb
@@ -1,0 +1,19 @@
+module WebAuthn::Camelize
+  def deep_camelize_keys(object)
+    if object.is_a?(Hash)
+      object.each_with_object(Hash.new) do |(key, value), result|
+        result[camelize(key)] = deep_camelize_keys(value)
+      end
+    else
+      object
+    end
+  end
+
+  def camelize(term)
+    term.to_s.
+      sub(/^(?:(?-mix:(?=a)b)(?=\b|[A-Z_])|\w)/) { |match| match.downcase }.
+      gsub(/(?:_|(\/))([a-z\d]*)/i) do
+        $2.capitalize
+      end.to_sym
+  end
+end

--- a/lib/webauthn/camelize.rb
+++ b/lib/webauthn/camelize.rb
@@ -1,19 +1,23 @@
-module WebAuthn::Camelize
-  def deep_camelize_keys(object)
-    if object.is_a?(Hash)
-      object.each_with_object(Hash.new) do |(key, value), result|
-        result[camelize(key)] = deep_camelize_keys(value)
-      end
-    else
-      object
-    end
-  end
+# frozen_string_literal: true
 
-  def camelize(term)
-    term.to_s.
-      sub(/^(?:(?-mix:(?=a)b)(?=\b|[A-Z_])|\w)/) { |match| match.downcase }.
-      gsub(/(?:_|(\/))([a-z\d]*)/i) do
+module WebAuthn
+  module Camelize
+    def deep_camelize_keys(object)
+      if object.is_a?(Hash)
+        object.each_with_object({}) do |(key, value), result|
+          result[camelize(key)] = deep_camelize_keys(value)
+        end
+      else
+        object
+      end
+    end
+
+    def camelize(term)
+      term.to_s
+          .sub(/^(?:(?-mix:(?=a)b)(?=\b|[A-Z_])|\w)/) { |match| match.downcase }
+          .gsub(/(?:_|(\/))([a-z\d]*)/i) do
         $2.capitalize
       end.to_sym
+    end
   end
 end

--- a/lib/webauthn/camelize_helper.rb
+++ b/lib/webauthn/camelize_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WebAuthn
-  module Camelize
+  module CamelizeHelper
     def deep_camelize_keys(object)
       if object.is_a?(Hash)
         object.each_with_object({}) do |(key, value), result|
@@ -13,11 +13,9 @@ module WebAuthn
     end
 
     def camelize(term)
-      term.to_s
-          .sub(/^(?:(?-mix:(?=a)b)(?=\b|[A-Z_])|\w)/) { |match| match.downcase }
-          .gsub(/(?:_|(\/))([a-z\d]*)/i) do
-        $2.capitalize
-      end.to_sym
+      first_term, *rest = term.to_s.split('_')
+
+      [first_term, *rest.map(&:capitalize)].join.to_sym
     end
   end
 end

--- a/lib/webauthn/public_key_credential/entity.rb
+++ b/lib/webauthn/public_key_credential/entity.rb
@@ -3,7 +3,7 @@
 module WebAuthn
   class PublicKeyCredential
     class Entity
-      include Camelize
+      include CamelizeHelper
 
       attr_reader :name
 

--- a/lib/webauthn/public_key_credential/entity.rb
+++ b/lib/webauthn/public_key_credential/entity.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "awrence"
-
 module WebAuthn
   class PublicKeyCredential
     class Entity
+      include Camelize
+
       attr_reader :name
 
       def initialize(name:)
@@ -12,7 +12,7 @@ module WebAuthn
       end
 
       def as_json
-        to_hash.to_camelback_keys
+        deep_camelize_keys(to_hash)
       end
 
       private

--- a/lib/webauthn/public_key_credential/options.rb
+++ b/lib/webauthn/public_key_credential/options.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-require "awrence"
 require "securerandom"
 
 module WebAuthn
   class PublicKeyCredential
     class Options
+      include Camelize
+
       CHALLENGE_LENGTH = 32
 
       attr_reader :timeout, :extensions, :relying_party
@@ -22,7 +23,7 @@ module WebAuthn
 
       # Argument wildcard for Ruby on Rails controller automatic object JSON serialization
       def as_json(*)
-        to_hash.to_camelback_keys
+        deep_camelize_keys(to_hash)
       end
 
       private

--- a/lib/webauthn/public_key_credential/options.rb
+++ b/lib/webauthn/public_key_credential/options.rb
@@ -5,7 +5,7 @@ require "securerandom"
 module WebAuthn
   class PublicKeyCredential
     class Options
-      include Camelize
+      include CamelizeHelper
 
       CHALLENGE_LENGTH = 32
 

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "android_key_attestation", "~> 0.3.0"
-  spec.add_dependency "awrence", "~> 1.1"
   spec.add_dependency "bindata", "~> 2.4"
   spec.add_dependency "cbor", "~> 0.5.9"
   spec.add_dependency "cose", "~> 1.1"


### PR DESCRIPTION
Avoids monkey patching Hash and removes a  dependency on an external gem. 
This is a simpler version of the rails' camelize and deep_transform_keys