### PR TITLE
Add ability to choose the algorithm when creating a credential with `FakeAuthenticator#make_credential`

### DIFF
--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -32,6 +32,7 @@ module WebAuthn
       backup_eligibility: false,
       backup_state: false,
       attested_credential_data: true,
+      credential_algorithm: nil,
       extensions: nil
     )
       rp_id ||= URI.parse(origin).host
@@ -47,6 +48,7 @@ module WebAuthn
         backup_eligibility: backup_eligibility,
         backup_state: backup_state,
         attested_credential_data: attested_credential_data,
+        algorithm: credential_algorithm,
         extensions: extensions
       )
 


### PR DESCRIPTION
## Summary

Now the `FakeAuthenticator#make_credential` supports an algorithm param that lets the caller choose between different supported COSE algorithms for the credential that will be created. This kinda mimics real authenticators that receive a list of COSE algorithms and they must create a credential for one of them.

For the moment, the supported COSE algorithms are `ES256`, `RS256` and `EdDSA`.