### PR TITLE
Fix JSON Serializer generating json with attributes with a null value

### DIFF
--- a/lib/webauthn/json_serializer.rb
+++ b/lib/webauthn/json_serializer.rb
@@ -13,7 +13,7 @@ module WebAuthn
       attributes.each_with_object({}) do |attribute_name, hash|
         value = send(attribute_name)
 
-        if value.respond_to?(:as_json)
+        if value && value.respond_to?(:as_json)
           hash[camelize(attribute_name)] = value.as_json
         elsif value
           hash[camelize(attribute_name)] = deep_camelize_keys(value)

--- a/spec/webauthn/public_key_credential/creation_options_spec.rb
+++ b/spec/webauthn/public_key_credential/creation_options_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe WebAuthn::PublicKeyCredential::CreationOptions do
       [{ type: "public-key", alg: -7 }, { type: "public-key", alg: -37 }, { type: "public-key", alg: -257 }]
     )
     expect(hash[:timeout]).to eq(120_000)
-    expect(hash[:excludeCredentials]).to be_nil
-    expect(hash[:authenticatorSelection]).to be_nil
-    expect(hash[:attestation]).to be_nil
-    expect(hash[:extensions]).to eq({})
     expect(hash[:challenge]).to be_truthy
+    expect(hash[:extensions]).to eq({})
+    expect(hash).not_to have_key(:excludeCredentials)
+    expect(hash).not_to have_key(:authenticatorSelection)
+    expect(hash).not_to have_key(:attestation)
   end
 
   it "accepts shorthand for exclude_credentials" do

--- a/spec/webauthn/public_key_credential/request_options_spec.rb
+++ b/spec/webauthn/public_key_credential/request_options_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe WebAuthn::PublicKeyCredential::RequestOptions do
 
     hash = options.as_json
 
-    expect(hash[:rpId]).to be_nil
     expect(hash[:timeout]).to eq(120_000)
     expect(hash[:allowCredentials]).to eq([])
-    expect(hash[:userVerification]).to be_nil
     expect(hash[:extensions]).to eq({})
     expect(hash[:challenge]).to be_truthy
+    expect(hash).not_to have_key(:userVerification)
+    expect(hash).not_to have_key(:rpId)
   end
 
   it "accepts shorthand for allow_credentials" do


### PR DESCRIPTION
Attempts to fix #441.

In Rails, `nil` responds to `as_json` therefore the attributes whose value is `nil` are added to the result of `as_json`, which may end up causing issues with some authenticators – as described in the associated issue.

This PR attempts to fix this by adding another condition to the if to skip if the value for the attribute is `nil`.