### PR TITLE
Prepare for `v3.2.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.2.1] - 2024-11-14
+
+### Fixed
+
+- Fix JSON Serializer generating json with attributes with a null value. [#442](https://github.com/cedarcode/webauthn-ruby/pull/442) @santiagorodriguez96
+
 ## [v3.2.0] - 2024-11-13
 
 ### Added

--- a/lib/webauthn/version.rb
+++ b/lib/webauthn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebAuthn
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end


### PR DESCRIPTION
This PR bumps the version of the gem to v3.2.1 and updates the `CHANGELOG.md` with the changes that will be introduced on this version.