### PR TITLE
Fix `PublicKeyCredential::Options#.as_json` not camelCase'ing keys of attributes with hash or arrays as values 

### DIFF
--- a/lib/webauthn/json_serializer.rb
+++ b/lib/webauthn/json_serializer.rb
@@ -4,19 +4,21 @@ module WebAuthn
   module JSONSerializer
     # Argument wildcard for Ruby on Rails controller automatic object JSON serialization
     def as_json(*)
-      to_hash_with_camelized_keys
+      deep_camelize_keys(to_hash)
     end
 
     private
 
-    def to_hash_with_camelized_keys
+    def to_hash
       attributes.each_with_object({}) do |attribute_name, hash|
         value = send(attribute_name)
 
-        if value && value.respond_to?(:as_json)
-          hash[camelize(attribute_name)] = value.as_json
-        elsif value
-          hash[camelize(attribute_name)] = deep_camelize_keys(value)
+        if value.respond_to?(:as_json)
+          value = value.as_json
+        end
+
+        if value
+          hash[attribute_name] = value
         end
       end
     end


### PR DESCRIPTION
Attempts to fix #444.

To fix this, this commit attempts to go back at the initial approach - before 0aab12406 – that first converts the object into a hash and then camel cases its keys, even though more iterations are performed on the object.