### PR TITLE
Prepare for `v3.2.2` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.2.2] - 2024-11-14
+
+### Fixed
+
+- Fix `PublicKeyCredential::Options#.as_json` not camelCase'ing keys of attributes with hash or arrays as values. [#445](https://github.com/cedarcode/webauthn-ruby/pull/445) [@santiagorodriguez96]
+
 ## [v3.2.1] - 2024-11-14
 
 ### Fixed

--- a/lib/webauthn/version.rb
+++ b/lib/webauthn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebAuthn
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 end


### PR DESCRIPTION
This PR bumps the version of the gem to `v3.2.2` and updates the `CHANGELOG.md` with the changes that will be introduced on this version.