### PR TITLE
Upgrade tpm-key_attestation dependency

### DIFF
--- a/spec/webauthn/attestation_statement/tpm_spec.rb
+++ b/spec/webauthn/attestation_statement/tpm_spec.rb
@@ -175,7 +175,11 @@ RSpec.describe "TPM attestation statement" do
           t_public.alg_type = ::TPM::ALG_ECC
           t_public.name_alg = name_alg
           t_public.parameters = pub_area_parameters
-          t_public.unique.buffer = credential_key.public_key.to_bn.to_s(2)[1..-1]
+
+          public_key_bytes = credential_key.public_key.to_bn.to_s(2)[1..-1]
+          coordinate_length = public_key_bytes.size / 2
+          t_public.unique.x.buffer = public_key_bytes[0..(coordinate_length - 1)]
+          t_public.unique.y.buffer = public_key_bytes[coordinate_length..-1]
 
           t_public.to_binary_s
         end
@@ -200,7 +204,11 @@ RSpec.describe "TPM attestation statement" do
               t_public.alg_type = ::TPM::ALG_ECC
               t_public.name_alg = name_alg
               t_public.parameters = pub_area_parameters
-              t_public.unique.buffer = create_ec_key.public_key.to_bn.to_s(2)[1..-1]
+
+              public_key_bytes = create_ec_key.public_key.to_bn.to_s(2)[1..-1]
+              coordinate_length = public_key_bytes.size / 2
+              t_public.unique.x.buffer = public_key_bytes[0..(coordinate_length - 1)]
+              t_public.unique.y.buffer = public_key_bytes[coordinate_length..-1]
 
               t_public.to_binary_s
             end

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cose", "~> 1.1"
   spec.add_dependency "openssl", ">= 2.2"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
-  spec.add_dependency "tpm-key_attestation", "~> 0.13.0"
+  spec.add_dependency "tpm-key_attestation", "~> 0.14.0"
 
   spec.add_development_dependency "base64", ">= 0.1.0"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"

--- a/webauthn.gemspec
+++ b/webauthn.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cose", "~> 1.1"
   spec.add_dependency "openssl", ">= 2.2"
   spec.add_dependency "safety_net_attestation", "~> 0.4.0"
-  spec.add_dependency "tpm-key_attestation", "~> 0.12.0"
+  spec.add_dependency "tpm-key_attestation", "~> 0.13.0"
 
   spec.add_development_dependency "base64", ">= 0.1.0"
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"


### PR DESCRIPTION
Upgrading tpm-key-attestation after release https://github.com/cedarcode/tpm-key_attestation/tree/v0.13.0