### PR TITLE
Remove `TokenBinding`

### DIFF
--- a/lib/webauthn/authenticator_response.rb
+++ b/lib/webauthn/authenticator_response.rb
@@ -13,7 +13,6 @@ module WebAuthn
   class ChallengeVerificationError < VerificationError; end
   class OriginVerificationError < VerificationError; end
   class RpIdVerificationError < VerificationError; end
-  class TokenBindingVerificationError < VerificationError; end
   class TypeVerificationError < VerificationError; end
   class UserPresenceVerificationError < VerificationError; end
   class UserVerifiedVerificationError < VerificationError; end
@@ -29,7 +28,6 @@ module WebAuthn
       rp_id ||= relying_party.id
 
       verify_item(:type)
-      verify_item(:token_binding)
       verify_item(:challenge, expected_challenge)
       verify_item(:origin, expected_origin)
       verify_item(:authenticator_data)
@@ -73,10 +71,6 @@ module WebAuthn
 
     def valid_type?
       client_data.type == type
-    end
-
-    def valid_token_binding?
-      client_data.valid_token_binding_format?
     end
 
     def valid_challenge?(expected_challenge)

--- a/lib/webauthn/client_data.rb
+++ b/lib/webauthn/client_data.rb
@@ -9,8 +9,6 @@ module WebAuthn
   class ClientDataMissingError < Error; end
 
   class ClientData
-    VALID_TOKEN_BINDING_STATUSES = ["present", "supported", "not-supported"].freeze
-
     def initialize(client_data_json)
       @client_data_json = client_data_json
     end
@@ -25,18 +23,6 @@ module WebAuthn
 
     def origin
       data["origin"]
-    end
-
-    def token_binding
-      data["tokenBinding"]
-    end
-
-    def valid_token_binding_format?
-      if token_binding
-        token_binding.is_a?(Hash) && VALID_TOKEN_BINDING_STATUSES.include?(token_binding["status"])
-      else
-        true
-      end
     end
 
     def hash

--- a/lib/webauthn/fake_client.rb
+++ b/lib/webauthn/fake_client.rb
@@ -10,16 +10,14 @@ module WebAuthn
   class FakeClient
     TYPES = { create: "webauthn.create", get: "webauthn.get" }.freeze
 
-    attr_reader :origin, :token_binding, :encoding
+    attr_reader :origin, :encoding
 
     def initialize(
       origin = fake_origin,
-      token_binding: nil,
       authenticator: WebAuthn::FakeAuthenticator.new,
       encoding: WebAuthn.configuration.encoding
     )
       @origin = origin
-      @token_binding = token_binding
       @authenticator = authenticator
       @encoding = encoding
     end
@@ -127,17 +125,11 @@ module WebAuthn
     attr_reader :authenticator
 
     def data_json_for(method, challenge)
-      data = {
+      {
         type: type_for(method),
         challenge: internal_encoder.encode(challenge),
         origin: origin
-      }
-
-      if token_binding
-        data[:tokenBinding] = token_binding
-      end
-
-      data.to_json
+      }.to_json
     end
 
     def encoder

--- a/spec/webauthn/authenticator_assertion_response_spec.rb
+++ b/spec/webauthn/authenticator_assertion_response_spec.rb
@@ -367,42 +367,6 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
     end
   end
 
-  describe "tokenBinding validation" do
-    let(:client) { WebAuthn::FakeClient.new(actual_origin, token_binding: token_binding, encoding: false) }
-
-    context "it has stuff" do
-      let(:token_binding) { { status: "supported" } }
-
-      it "verifies" do
-        expect(
-          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
-        ).to be_truthy
-      end
-
-      it "is valid" do
-        expect(
-          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
-        ).to be_truthy
-      end
-    end
-
-    context "has an invalid format" do
-      let(:token_binding) { "invalid token binding format" }
-
-      it "doesn't verify" do
-        expect {
-          assertion_response.verify(original_challenge, public_key: credential_public_key, sign_count: 0)
-        }.to raise_exception(WebAuthn::TokenBindingVerificationError)
-      end
-
-      it "isn't valid" do
-        expect(
-          assertion_response.valid?(original_challenge, public_key: credential_public_key, sign_count: 0)
-        ).to be_falsy
-      end
-    end
-  end
-
   describe "rp_id validation" do
     before do
       WebAuthn.configuration.rp_id = "different-rp_id"

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -479,36 +479,6 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
   end
 
-  describe "tokenBinding validation" do
-    let(:client) { WebAuthn::FakeClient.new(origin, token_binding: token_binding, encoding: false) }
-
-    context "it has stuff" do
-      let(:token_binding) { { status: "supported" } }
-
-      it "verifies" do
-        expect(attestation_response.verify(original_challenge, origin)).to be_truthy
-      end
-
-      it "is valid" do
-        expect(attestation_response.valid?(original_challenge, origin)).to be_truthy
-      end
-    end
-
-    context "has an invalid format" do
-      let(:token_binding) { "invalid token binding format" }
-
-      it "doesn't verify" do
-        expect {
-          attestation_response.verify(original_challenge, origin)
-        }.to raise_exception(WebAuthn::TokenBindingVerificationError)
-      end
-
-      it "isn't valid" do
-        expect(attestation_response.valid?(original_challenge, origin)).to be_falsy
-      end
-    end
-  end
-
   describe "user presence" do
     context "when UP is not set" do
       let(:public_key_credential) { client.create(challenge: original_challenge, user_present: false) }


### PR DESCRIPTION
## Summary
Removed `token binding` support

## Why
Token binding has been officially removed from the `WebAuthn` specification, as reflected in [w3c/webauthn#1630](https://github.com/w3c/webauthn/pull/1630).