### PR TITLE
docs: Fix tpm-key_attestation version number in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Updated `tpm-key_attestation` dependency from `~> 1.12.0` to `~> 1.14.0`. [#449](https://github.com/cedarcode/webauthn-ruby/pull/449) [@brauliomartinezlm], [@nicolastemciuc]
+- Updated `tpm-key_attestation` dependency from `~> 0.12.0` to `~> 0.14.0`. [#449](https://github.com/cedarcode/webauthn-ruby/pull/449) [@brauliomartinezlm], [@nicolastemciuc]
 
 ## [v3.2.2] - 2024-11-14
 


### PR DESCRIPTION
Thanks for the recent update!

Would you mind checking the version number in CHANGELOG.md? It looks a bit different from the actual version.