### PR TITLE
Update CI to run on `ubuntu-22`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Motivation

`ubuntu-20` images are being deprecated:

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down

## Context

This PR updates the CI ro run on `ubuntu-22` which is the latest `ubuntu` image available.