### PR TITLE
Start tracking `Gemfile.lock`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           - truffleruby
     steps:
     - uses: actions/checkout@v4
+    - run: rm Gemfile.lock
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 # rspec failure tracking
 .rspec_status
 
-/Gemfile.lock
 /gemfiles/*.gemfile.lock
 .byebug_history
 /spec/conformance/metadata.zip

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,94 @@
+PATH
+  remote: .
+  specs:
+    webauthn (3.4.0)
+      android_key_attestation (~> 0.3.0)
+      bindata (~> 2.4)
+      cbor (~> 0.5.9)
+      cose (~> 1.1)
+      openssl (>= 2.2)
+      safety_net_attestation (~> 0.4.0)
+      tpm-key_attestation (~> 0.14.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    android_key_attestation (0.3.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bindata (2.5.0)
+    byebug (11.1.3)
+    cbor (0.5.9.8)
+    cose (1.3.1)
+      cbor (~> 0.5.9)
+      openssl-signature_algorithm (~> 1.0)
+    diff-lcs (1.6.0)
+    jwt (2.10.1)
+      base64
+    openssl (3.3.0)
+    openssl-signature_algorithm (1.3.0)
+      openssl (> 2.0)
+    parallel (1.26.3)
+    parser (3.3.7.1)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rexml (3.4.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.3)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    rubocop (1.9.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.38.1)
+      parser (>= 3.3.1.0)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (2.2.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.13.0)
+    safety_net_attestation (0.4.0)
+      jwt (~> 2.0)
+    tpm-key_attestation (0.14.0)
+      bindata (~> 2.4)
+      openssl (> 2.0)
+      openssl-signature_algorithm (~> 1.0)
+    unicode-display_width (2.6.0)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  base64 (>= 0.1.0)
+  bundler (>= 1.17, < 3.0)
+  byebug (~> 11.0)
+  rake (~> 13.0)
+  rspec (~> 3.8)
+  rubocop (~> 1.9.1)
+  rubocop-rake (~> 0.5.1)
+  rubocop-rspec (~> 2.2.0)
+  webauthn!
+
+BUNDLED WITH
+   2.6.2


### PR DESCRIPTION
## Summary

This PR adds the `Gemfile.lock` file, this way we can keep track of the gems versions used in development.