### PR TITLE
Use `allowed_origins` instead of deprecated `origin` in test

### DIFF
--- a/spec/webauthn/authenticator_assertion_response_spec.rb
+++ b/spec/webauthn/authenticator_assertion_response_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe WebAuthn::AuthenticatorAssertionResponse do
   end
 
   before do
-    WebAuthn.configuration.origin = origin
+    WebAuthn.configuration.allowed_origins = [origin]
   end
 
   context "when everything's in place" do

--- a/spec/webauthn/authenticator_attestation_response_spec.rb
+++ b/spec/webauthn/authenticator_attestation_response_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
   context "when everything's in place" do
     context "when there is a single origin" do
       before do
-        WebAuthn.configuration.origin = origin
+        WebAuthn.configuration.allowed_origins = [origin]
       end
 
       it_behaves_like "a valid attestation response"
@@ -131,7 +131,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
       before do
         WebAuthn.configuration.attestation_root_certificates_finders = finder_for('feitian_ft_fido_0200.pem')
-        WebAuthn.configuration.origin = origin
+        WebAuthn.configuration.allowed_origins = [origin]
       end
 
       it_behaves_like "a valid attestation response"
@@ -209,7 +209,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     it_behaves_like "a valid attestation response"
@@ -250,7 +250,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
     before do
       WebAuthn.configuration.attestation_root_certificates_finders = finder_for('yubico_u2f_root.pem')
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     it_behaves_like "a valid attestation response"
@@ -286,7 +286,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
       WebAuthn.configure do |config|
         config.algorithms.concat(%w(RS1))
       end
@@ -347,7 +347,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
       allow(attestation_response.attestation_statement).to receive(:time).and_return(time)
     end
 
@@ -391,7 +391,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
       let(:origin) { seeds[:android_key_direct][:origin] }
 
       before do
-        WebAuthn.configuration.origin = origin
+        WebAuthn.configuration.allowed_origins = [origin]
       end
 
       it_behaves_like "a valid attestation response"
@@ -481,7 +481,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
 
       # Apple credential certificate expires after 3 days apparently.
       # Seed data was obtained 22nd Feb 2021, so we are simulating validation within that 3 day timeframe
@@ -504,7 +504,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
   context "when no client data received" do
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     it "returns user-friendly error if no client data received" do
@@ -534,7 +534,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     end
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     context "matches the default one" do
@@ -610,7 +610,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     let(:client) { WebAuthn::FakeClient.new(origin, token_binding: token_binding, encoding: false) }
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     context "it has stuff" do
@@ -718,7 +718,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
   describe "user verification" do
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     context "when UV is not set" do
@@ -738,7 +738,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
 
   describe "attested credential data verification" do
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     context "when AT is not set" do
@@ -783,7 +783,7 @@ RSpec.describe WebAuthn::AuthenticatorAttestationResponse do
     before do
       attestation_response.attestation_statement.instance_variable_get(:@statement)["sig"] =
         "corrupted signature".b
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     context "when verification is set to true" do

--- a/spec/webauthn/credential_spec.rb
+++ b/spec/webauthn/credential_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Credential" do
   let(:origin) { fake_origin }
 
   before do
-    WebAuthn.configuration.origin = origin
+    WebAuthn.configuration.allowed_origins = [origin]
   end
 
   describe ".from_create" do

--- a/spec/webauthn/public_key_credential_with_assertion_spec.rb
+++ b/spec/webauthn/public_key_credential_with_assertion_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "PublicKeyCredentialWithAssertion" do
     end
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     it "works" do

--- a/spec/webauthn/public_key_credential_with_attestation_spec.rb
+++ b/spec/webauthn/public_key_credential_with_attestation_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "PublicKeyCredentialWithAttestation" do
     let(:origin) { fake_origin }
 
     before do
-      WebAuthn.configuration.origin = origin
+      WebAuthn.configuration.allowed_origins = [origin]
     end
 
     it "works" do

--- a/spec/webauthn/relying_party_spec.rb
+++ b/spec/webauthn/relying_party_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe "RelyingParty" do
 
     before do
       WebAuthn.configure do |config|
-        config.origin = "https://www.example.com"
+        config.allowed_origins = ["https://www.example.com"]
         config.rp_name = "Example Consumer page"
       end
     end
@@ -391,7 +391,7 @@ RSpec.describe "RelyingParty" do
 
     before do
       WebAuthn.configure do |config|
-        config.origin = "https://www.example.com"
+        config.allowed_origins = ["https://www.example.com"]
         config.rp_name = "Example Consumer page"
       end
     end


### PR DESCRIPTION
## Summary
Update test configuration to use `allowed_origins` instead of the deprecated `origin`.

## Why?
The use of the deprecated `origin` config was generating excessive deprecation warnings during test runs.