### PR TITLE
Test against different OpenSSL library versions

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -1,0 +1,35 @@
+name: Install OpenSSL
+
+inputs:
+  version:
+    description: 'The version of OpenSSL to install'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache OpenSSL library
+      id: cache-openssl
+      uses: actions/cache@v4
+      with:
+        path: ~/openssl
+        key: openssl-${{ inputs.version }}
+
+    - name: Compile OpenSSL library
+      if: steps.cache-openssl.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p tmp/build-openssl && cd tmp/build-openssl
+        case ${{ inputs.version }} in
+        1.1.*)
+          OPENSSL_COMMIT=OpenSSL_
+          OPENSSL_COMMIT+=$(echo ${{ inputs.version  }} | sed -e 's/\./_/g')
+          git clone -b $OPENSSL_COMMIT --depth 1 https://github.com/openssl/openssl.git .
+          echo "Git commit: $(git rev-parse HEAD)"
+          ./Configure --prefix=$HOME/openssl --libdir=lib linux-x86_64
+          make depend && make -j4 && make install_sw
+          ;;
+        *)
+          echo "Don't know how to build OpenSSL ${{ inputs.version }}"
+          ;;
+        esac

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -8,15 +8,15 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Cache OpenSSL library
-      id: cache-openssl
-      uses: actions/cache@v4
+    - name: Restore cached OpenSSL library
+      id: cache-openssl-restore
+      uses: actions/cache/restore@v4
       with:
         path: ~/openssl
         key: openssl-${{ inputs.version }}
 
     - name: Compile OpenSSL library
-      if: steps.cache-openssl.outputs.cache-hit != 'true'
+      if: steps.cache-openssl-restore.outputs.cache-hit != 'true'
       shell: bash
       run: |
         mkdir -p tmp/build-openssl && cd tmp/build-openssl
@@ -33,3 +33,11 @@ runs:
           echo "Don't know how to build OpenSSL ${{ inputs.version }}"
           ;;
         esac
+
+    - name: Save OpenSSL library cache
+      if: steps.cache-openssl-restore.outputs.cache-hit != 'true'
+      id: cache-openssl-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/openssl
+        key: ${{ steps.cache-openssl-restore.outputs.cache-primary-key }}

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -29,6 +29,18 @@ runs:
           ./Configure --prefix=$HOME/openssl --libdir=lib linux-x86_64
           make depend && make -j4 && make install_sw
           ;;
+        3.*)
+          OPENSSL_COMMIT=openssl-
+          OPENSSL_COMMIT+=$(echo ${{ inputs.version  }})
+          git clone -b $OPENSSL_COMMIT --depth 1 https://github.com/openssl/openssl.git .
+          echo "Git commit: $(git rev-parse HEAD)"
+          if [[ ${{ inputs.version }} == 3.5* ]]; then
+            ./Configure --prefix=$HOME/openssl --libdir=lib enable-fips no-tests no-legacy
+          else
+            ./Configure --prefix=$HOME/openssl --libdir=lib enable-fips no-tests
+          fi
+          make -j4 && make install_sw && make install_fips
+          ;;
         *)
           echo "Don't know how to build OpenSSL ${{ inputs.version }}"
           ;;

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -1,0 +1,66 @@
+name: Install Ruby
+
+inputs:
+  version:
+    description: 'The version of Ruby to install'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache Ruby
+      id: ruby-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/rubies/ruby-${{ inputs.version }}
+        key: ruby-${{ inputs.version }}-openssl-1.1.1w
+
+    - name: Install Ruby
+      if: steps.ruby-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        latest_patch=$(curl -s https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ \
+           | grep -oP "ruby-${{ inputs.version }}\.\d+\.tar\.xz" \
+           | grep -oP "\d+(?=\.tar\.xz)" \
+           | sort -V | tail -n 1)
+        wget https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        tar -xJvf ruby-${{ inputs.version }}.${latest_patch}.tar.xz
+        cd ruby-${{ inputs.version }}.${latest_patch}
+        ./configure --prefix=$HOME/rubies/ruby-${{ inputs.version }} --with-openssl-dir=$HOME/openssl
+        make
+        make install
+
+    - name: Update PATH
+      shell: bash
+      run: |
+        echo "~/rubies/ruby-${{ inputs.version }}/bin" >> $GITHUB_PATH
+
+    - name: Install Bundler
+      shell: bash
+      run: |
+        case ${{ inputs.version }} in
+        2.7* | 3.*)
+          echo "Skipping Bundler installation for Ruby ${{ inputs.version }}"
+          ;;
+        2.5* | 2.6*)
+          gem install bundler -v '~> 2.3.0'
+          ;;
+        *)
+          echo "Don't know how to install Bundler for Ruby ${{ inputs.version }}"
+          ;;
+        esac
+
+    - name: Cache Bundler Install
+      id: bundler-cache
+      uses: actions/cache@v4
+      env:
+        GEMFILE: ${{ env.BUNDLE_GEMFILE || 'Gemfile' }}
+      with:
+        path: ~/bundler/cache
+        key: bundler-ruby-${{ inputs.version }}-${{ hashFiles(env.Gemfile, 'webauthn.gemspec') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        bundle config set --local path ~/bundler/cache
+        bundle install

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -8,15 +8,15 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Cache Ruby
-      id: ruby-cache
-      uses: actions/cache@v4
+    - name: Restore cached Ruby installation
+      id: cache-ruby-restore
+      uses: actions/cache/restore@v4
       with:
         path: ~/rubies/ruby-${{ inputs.version }}
         key: ruby-${{ inputs.version }}-openssl-1.1.1w
 
     - name: Install Ruby
-      if: steps.ruby-cache.outputs.cache-hit != 'true'
+      if: steps.cache-ruby-restore.outputs.cache-hit != 'true'
       shell: bash
       run: |
         latest_patch=$(curl -s https://cache.ruby-lang.org/pub/ruby/${{ inputs.version }}/ \
@@ -50,17 +50,32 @@ runs:
           ;;
         esac
 
+    - name: Save Ruby installation cache
+      if: steps.cache-ruby-restore.outputs.cache-hit != 'true'
+      id: cache-ruby-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/rubies/ruby-${{ inputs.version }}
+        key: ${{ steps.cache-ruby-restore.outputs.cache-primary-key }}
+
     - name: Cache Bundler Install
-      id: bundler-cache
-      uses: actions/cache@v4
+      id: cache-bundler-restore
+      uses: actions/cache/restore@v4
       env:
         GEMFILE: ${{ env.BUNDLE_GEMFILE || 'Gemfile' }}
       with:
         path: ~/bundler/cache
-        key: bundler-ruby-${{ inputs.version }}-${{ hashFiles(env.Gemfile, 'webauthn.gemspec') }}
+        key: bundler-ruby-${{ inputs.version }}-openssl-1.1.1w-${{ hashFiles(env.Gemfile, 'webauthn.gemspec') }}
 
     - name: Install dependencies
       shell: bash
       run: |
         bundle config set --local path ~/bundler/cache
         bundle install
+
+    - name: Save Bundler Install cache
+      id: cache-bundler-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/bundler/cache
+        key: ${{ steps.cache-bundler-restore.outputs.cache-primary-key }}

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ~/rubies/ruby-${{ inputs.version }}
-        key: ruby-${{ inputs.version }}-${{ inputs.openssl-version }}
+        key: ruby-${{ inputs.version }}-with-openssl-${{ inputs.openssl-version }}
 
     - name: Install Ruby
       if: steps.cache-ruby-restore.outputs.cache-hit != 'true'

--- a/.github/actions/install-ruby/action.yml
+++ b/.github/actions/install-ruby/action.yml
@@ -4,6 +4,9 @@ inputs:
   version:
     description: 'The version of Ruby to install'
     required: true
+  openssl-version:
+    description: 'The version of OpenSSL used'
+    required: true
 
 runs:
   using: 'composite'
@@ -13,7 +16,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ~/rubies/ruby-${{ inputs.version }}
-        key: ruby-${{ inputs.version }}-openssl-1.1.1w
+        key: ruby-${{ inputs.version }}-${{ inputs.openssl-version }}
 
     - name: Install Ruby
       if: steps.cache-ruby-restore.outputs.cache-hit != 'true'
@@ -65,7 +68,7 @@ runs:
         GEMFILE: ${{ env.BUNDLE_GEMFILE || 'Gemfile' }}
       with:
         path: ~/bundler/cache
-        key: bundler-ruby-${{ inputs.version }}-openssl-1.1.1w-${{ hashFiles(env.Gemfile, 'webauthn.gemspec') }}
+        key: bundler-ruby-${{ inputs.version }}-${{ inputs.openssl-version }}-${{ hashFiles(env.Gemfile, 'webauthn.gemspec') }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   test:
+    name: 'Test Ruby ${{ matrix.ruby }} with OpenSSL ${{ matrix.openssl }}'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,17 @@ jobs:
           - '2.7'
           - '2.6'
           - '2.5'
-          - truffleruby
+        openssl:
+          - '3.5.3'
+          - '3.4.2'
+          - '3.3.4'
+          - '3.2.5'
+          - '3.1.8'
+          - '3.0.17'
+          - '1.1.1w'
+        include:
+          - ruby: truffleruby
+
     steps:
     - uses: actions/checkout@v5
 
@@ -36,14 +46,14 @@ jobs:
       if: matrix.ruby != 'truffleruby'
       uses: ./.github/actions/install-openssl
       with:
-        version: "1.1.1w"
+        version: ${{ matrix.openssl }}
 
     - name: Manually set up Ruby
       if: matrix.ruby != 'truffleruby'
       uses: ./.github/actions/install-ruby
       with:
         version: ${{ matrix.ruby }}
-        openssl-version: "1.1.1w"
+        openssl-version: ${{ matrix.openssl }}
 
     - name: Set up Ruby
       if: matrix.ruby == 'truffleruby'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,6 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
-          - '3.0'
-          - '2.7'
-          - '2.6'
-          - '2.5'
         openssl:
           - '3.5.3'
           - '3.4.2'
@@ -38,6 +34,14 @@ jobs:
           - '1.1.1w'
         include:
           - ruby: truffleruby
+          - ruby: '3.0'
+            openssl: '1.1.1w'
+          - ruby: '2.7'
+            openssl: '1.1.1w'
+          - ruby: '2.6'
+            openssl: '1.1.1w'
+          - ruby: '2.5'
+            openssl: '1.1.1w'
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,26 @@ jobs:
           - truffleruby
     steps:
     - uses: actions/checkout@v5
-    - uses: ruby/setup-ruby@v1
+
+    - name: Install OpenSSL
+      if: matrix.ruby != 'truffleruby'
+      uses: ./.github/actions/install-openssl
+      with:
+        version: "1.1.1w"
+
+    - name: Manually set up Ruby
+      if: matrix.ruby != 'truffleruby'
+      uses: ./.github/actions/install-ruby
+      with:
+        version: ${{ matrix.ruby }}
+
+    - name: Set up Ruby
+      if: matrix.ruby == 'truffleruby'
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+
     - run: bundle exec rspec
       env:
         RUBYOPT: ${{ startsWith(matrix.ruby, '3.4') && '--enable=frozen-string-literal' || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       uses: ./.github/actions/install-ruby
       with:
         version: ${{ matrix.ruby }}
+        openssl-version: "1.1.1w"
 
     - name: Set up Ruby
       if: matrix.ruby == 'truffleruby'


### PR DESCRIPTION
## Motivation

Similar to https://github.com/cedarcode/tpm-key_attestation/pull/49.

> We got a notification that `ubuntu-20` images are being deprecated:
> 
> https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down
> 
> After upgrading to `ubuntu-22` or `ubuntu-24` a lot of tests started to break due to the Rubies on those images coming with OpenSSL version 3+. That means that, by upgrading, we wouldn't have any way of testing against OpenSSL 1.1.1w
> 
> We still want to test against OpenSSL `1.1.1w` despite it being EOL. 

## Summary

This PR updates our CI to manually install OpenSSL and Ruby so that we can test against different OpenSSL versions, without having to rely on the OpenSSL version that comes with the OS' ruby.