### PR TITLE
Prepare for `v3.4.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v3.4.1] - 2025-06-06
+
+- Avoid requiring `base64` as it's not a direct dependency. [#459](https://github.com/cedarcode/webauthn-ruby/pull/459)[@santiagorodriguez96]
+
 ## [v3.4.0] - 2025-02-17
 
 - Added support for Webauthn.config and RelayingParty to accept multiple allowed_origins. [#431](https://github.com/cedarcode/webauthn-ruby/pull/431)[@obroshnij]
@@ -417,6 +421,7 @@ Note: Both additions should help making it compatible with Chrome for Android 70
   - `WebAuthn::AuthenticatorAttestationResponse.valid?` can be used to validate fido-u2f attestations returned by the browser
 - Works with ruby 2.5
 
+[v3.4.1]: https://github.com/cedarcode/webauthn-ruby/compare/v3.4.0...v3.4.1/
 [v3.4.0]: https://github.com/cedarcode/webauthn-ruby/compare/v3.3.0...v3.4.0/
 [v3.3.0]: https://github.com/cedarcode/webauthn-ruby/compare/v3.2.2...v3.3.0/
 [v3.2.2]: https://github.com/cedarcode/webauthn-ruby/compare/v3.2.1...v3.2.2/

--- a/lib/webauthn/version.rb
+++ b/lib/webauthn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebAuthn
-  VERSION = "3.4.0"
+  VERSION = "3.4.1"
 end


### PR DESCRIPTION
This PR bumps the version of the gem to `v3.4.1` and updates the `CHANGELOG.md` with the changes that will be introduced on this version.