### PR TITLE
Fix `Rubocop`'s `Lint/UselessAccessModifier` offense

### DIFF
--- a/spec/conformance/server.rb
+++ b/spec/conformance/server.rb
@@ -151,8 +151,6 @@ error 500 do
   MSG
 end
 
-private
-
 def render_ok(params = {})
   JSON.dump({ status: "ok", errorMessage: "" }.merge!(params))
 end


### PR DESCRIPTION
See https://github.com/rubocop/rubocop/commit/0b12a1ce4e2ecb732d9dda4d1b36dfc0aa09dc2c.