### PR TITLE
fix docs: update deprecated origin and verify_registration usage

### DIFF
--- a/docs/advanced_configuration.md
+++ b/docs/advanced_configuration.md
@@ -102,7 +102,7 @@ session[:creation_challenge] = options.challenge
 begin
   webauthn_credential = relying_party.verify_registration(
     params[:publicKeyCredential],
-    params[:create_challenge]
+    session[:creation_challenge]
   )
 
   # Store Credential ID, Credential Public Key and Sign Count for future authentications


### PR DESCRIPTION
This PR fixes two documentation issues:

1. Replace deprecated `origin` with `allowed_origins` in documentation
1. Fix `verify_registration` example to use session challenge
   - Updated documentation example to use `session[:creation_challenge]`

Thank you for maintaining this project!