### PR TITLE
Support `rubocop` plugin API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
   - rubocop-rake
 


### PR DESCRIPTION
#### Warnings

```sh
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in webauthn-ruby/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rake extension supports plugin, specify `plugins: rubocop-rake` instead of `require: rubocop-rake` in webauthn-ruby/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```