### PR TITLE
Avoid setting `enable-frozen-string-literal` RUBYOPT for Ruby 3.4 in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,6 @@ jobs:
         bundler-cache: true
 
     - run: bundle exec rspec
-      env:
-        RUBYOPT: ${{ startsWith(matrix.ruby, '3.4') && '--enable=frozen-string-literal' || '' }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This flag is redundant for our own code since we already have the `# frozen_string_literal: true` directive at the top of each file, enforced by RuboCop.

While the flag could theoretically catch frozen string issues in dependencies, I don't think we want our CI to fail because of frozen string errors in gems we don't have control of.