### PR TITLE
Replace `@github/webauthn-json` references with built-in browser methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ session[:authentication_challenge] = options.challenge
 # If inside a Rails controller, `render json: options` will just work.
 # I.e. it will encode and convert the options to JSON automatically.
 
-# For your frontend code, you might find the built-in browser methods useful.
+# For your frontend code, you might find the [built-in browser methods](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential) useful.
 # Especially the built-in `PublicKeyCredential.parseRequestOptionsFromJSON(options)` for decoding the options, and
 # the built-in `credential.toJSON()` for sending the `PublicKeyCredential` object back to the server.
 ```

--- a/README.md
+++ b/README.md
@@ -191,15 +191,15 @@ session[:creation_challenge] = options.challenge
 # If inside a Rails controller, `render json: options` will just work.
 # I.e. it will encode and convert the options to JSON automatically.
 
-# For your frontend code, you might find @github/webauthn-json npm package useful.
-# Especially for handling the necessary decoding of the options, and sending the
-# `PublicKeyCredential` object back to the server.
+# For your frontend code, you might find the built-in browser methods useful.
+# Especially the built-in `PublicKeyCredential.parseCreationOptionsFromJSON(options)` for decoding the options, and
+# the built-in `credential.toJSON()` for sending the `PublicKeyCredential` object back to the server.
 ```
 
 #### Verification phase
 
 ```ruby
-# Assuming you're using @github/webauthn-json package to send the `PublicKeyCredential` object back
+# Assuming you're using the built-in `credential.toJSON()` to send the `PublicKeyCredential` object back
 # in params[:publicKeyCredential]:
 webauthn_credential = WebAuthn::Credential.from_create(params[:publicKeyCredential])
 
@@ -238,9 +238,9 @@ session[:authentication_challenge] = options.challenge
 # If inside a Rails controller, `render json: options` will just work.
 # I.e. it will encode and convert the options to JSON automatically.
 
-# For your frontend code, you might find @github/webauthn-json npm package useful.
-# Especially for handling the necessary decoding of the options, and sending the
-# `PublicKeyCredential` object back to the server.
+# For your frontend code, you might find the built-in browser methods useful.
+# Especially the built-in `PublicKeyCredential.parseRequestOptionsFromJSON(options)` for decoding the options, and
+# the built-in `credential.toJSON()` for sending the `PublicKeyCredential` object back to the server.
 ```
 
 #### Verification phase
@@ -250,7 +250,7 @@ interface returned by the browser to the stored `credential_id`. The correspondi
 attributes must be passed as keyword arguments to the `verify` method call.
 
 ```ruby
-# Assuming you're using @github/webauthn-json package to send the `PublicKeyCredential` object back
+# Assuming you're using the built-in `credential.toJSON()` to send the `PublicKeyCredential` object back
 # in params[:publicKeyCredential]:
 webauthn_credential = WebAuthn::Credential.from_get(params[:publicKeyCredential])
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ session[:creation_challenge] = options.challenge
 # If inside a Rails controller, `render json: options` will just work.
 # I.e. it will encode and convert the options to JSON automatically.
 
-# For your frontend code, you might find the built-in browser methods useful.
-# Especially the built-in `PublicKeyCredential.parseCreationOptionsFromJSON(options)` for decoding the options, and
-# the built-in `credential.toJSON()` for sending the `PublicKeyCredential` object back to the server.
+# For your frontend code, you might find the [built-in browser methods](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential) useful.
+# The built-in `PublicKeyCredential.parseCreationOptionsFromJSON(options)` allows you to decode the options,
+# and the built-in `credential.toJSON()` to send the `PublicKeyCredential` object back to the server.
 ```
 
 #### Verification phase
@@ -239,8 +239,8 @@ session[:authentication_challenge] = options.challenge
 # I.e. it will encode and convert the options to JSON automatically.
 
 # For your frontend code, you might find the [built-in browser methods](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential) useful.
-# Especially the built-in `PublicKeyCredential.parseRequestOptionsFromJSON(options)` for decoding the options, and
-# the built-in `credential.toJSON()` for sending the `PublicKeyCredential` object back to the server.
+# The built-in `PublicKeyCredential.parseRequestOptionsFromJSON(options)` allows you to decode the options,
+# and the built-in `credential.toJSON()` to send the `PublicKeyCredential` object back to the server.
 ```
 
 #### Verification phase


### PR DESCRIPTION
First of all, thank you so much for building and maintaining this amazing gem. It has been incredibly helpful and I truly appreciate all the work that has gone into it.

## Summary

ref. https://github.com/github/webauthn-json/blob/7a29471446919d9b45864631f84816c026c9dad8/README.md

`@github/webauthn-json` was deprecated in March 2025, as all major browsers now natively support the following methods:

- `PublicKeyCredential.parseCreationOptionsFromJSON()`
- `PublicKeyCredential.parseRequestOptionsFromJSON()`
- `PublicKeyCredential.prototype.toJSON()`

This PR updates the README to reflect that, replacing references to `@github/webauthn-json` with the built-in browser methods.