### PR TITLE
Add `WebAuthn.generate_user_handle` as an alias for `generate_user_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ end
 ```ruby
 # Generate and store the WebAuthn User ID the first time the user registers a credential
 if !user.webauthn_id
-  user.update!(webauthn_id: WebAuthn.generate_user_id)
+  user.update!(webauthn_id: WebAuthn.generate_user_handle)
 end
 
 options = WebAuthn::Credential.options_for_create(
@@ -327,13 +327,15 @@ A list of all currently defined extensions:
 
 ## API
 
-#### `WebAuthn.generate_user_id`
+#### `WebAuthn.generate_user_handle`
 
 Generates a [WebAuthn User Handle](https://www.w3.org/TR/webauthn-2/#user-handle) that follows the WebAuthn spec recommendations.
 
 ```ruby
-WebAuthn.generate_user_id # "lWoMZTGf_ml2RoY5qPwbwrkxrvTqWjGOxEoYBgxft3zG-LlrICvE-y8bxFi06zMyIOyNsJoWx4Fa2TOqoRmnxA"
+WebAuthn.generate_user_handle # "lWoMZTGf_ml2RoY5qPwbwrkxrvTqWjGOxEoYBgxft3zG-LlrICvE-y8bxFi06zMyIOyNsJoWx4Fa2TOqoRmnxA"
 ```
+
+> `WebAuthn.generate_user_id` is also available as an alias.
 
 #### `WebAuthn::Credential.options_for_create(options)`
 

--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -13,4 +13,6 @@ module WebAuthn
   def self.generate_user_id
     configuration.encoder.encode(SecureRandom.random_bytes(64))
   end
+
+  singleton_class.send(:alias_method, :generate_user_handle, :generate_user_id)
 end

--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -10,9 +10,10 @@ require "webauthn/version"
 module WebAuthn
   TYPE_PUBLIC_KEY = "public-key"
 
-  def self.generate_user_id
-    configuration.encoder.encode(SecureRandom.random_bytes(64))
+  class << self
+    def generate_user_id
+      configuration.encoder.encode(SecureRandom.random_bytes(64))
+    end
+    alias_method :generate_user_handle, :generate_user_id
   end
-
-  singleton_class.send(:alias_method, :generate_user_handle, :generate_user_id)
 end


### PR DESCRIPTION
Follow-up to #502

The value returned by `WebAuthn.generate_user_id` is actually a [user handle](https://www.w3.org/TR/webauthn-2/#user-handle), not a user id — it's an opaque, randomly generated value that the spec recommends *not* to contain any personally identifying information. The name `generate_user_id` is misleading because it suggests using an application's own user identifier.

This PR adds `WebAuthn.generate_user_handle` as a clearer, spec-aligned name and updates the README to use it. `WebAuthn.generate_user_id` is kept as an alias, so this is fully backwards compatible.